### PR TITLE
Discard unneeded events in BPF

### DIFF
--- a/bpf/trace.bpf.c
+++ b/bpf/trace.bpf.c
@@ -3,26 +3,48 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 
+/* Function trace event */
 struct event_t {
-    __u64 cookie;
+    __u64 cookie; /* Cookie is a function identifier */
 };
 
+/* Function trace event ring buffer */
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 28); /* 256MB buffer */
 } events SEC(".maps");
+
+/* Function trace report tracking map */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 40960); /* Maximum number of function symbols to track */
+    __type(key, u64);           /* Function cookie */
+    __type(value, u8);          /* Report marker */
+} seen_funcs SEC(".maps");
 
 long ringbuffer_flags = 0;
 
 SEC("uprobe/handle_user_function")
 int handle_user_function(struct pt_regs *ctx) {
 	__u64 cookie = bpf_get_attach_cookie(ctx);
+	u8 seen = 1;
 
 	bpf_printk("handle user function with cookie %llu\n", cookie);
+
+	/* Check if the function has been already reported */
+	if (bpf_map_lookup_elem(&seen_funcs, &cookie)) {
+		bpf_printk("function with cookie %llu already reported, skipping\n", cookie);
+
+		return 0;
+	}
+
+	/* Track which functions have been reported */
+	bpf_map_update_elem(&seen_funcs, &cookie, &seen, BPF_ANY);
 
 	struct event_t *event = bpf_ringbuf_reserve(&events, sizeof(struct event_t), 0);
 	if (!event) {
 		bpf_printk("error submitting event to ring buffer for user function with cookie %s\n", cookie);
+
 		return 0;
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/term v0.31.0
 )
 
 require (
@@ -17,6 +18,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,10 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
+golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,28 @@
+package output
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+)
+
+func PrintRight(text string) {
+	// Get terminal width.
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		width = 80
+	}
+
+	// Set padding.
+	padding := width - len(text)
+	if padding < 0 {
+		padding = 0
+	}
+
+	fmt.Printf("\r%s%s", spaces(padding), text)
+}
+
+func spaces(n int) string {
+	return fmt.Sprintf("%*s", n, "")
+}


### PR DESCRIPTION
This PR aims to optimize resources to prevent the event ring buffer from being filled because of userspace not being able to catch up fast enough.

In particular, we don't need to report again and again the same functions already been reported, that is, no need to reserve space in the ring buffer every time a user function trigger the uprobe, but only for interesting functions.

Furthermore, this PR introduces a new gauge that monitor the event per second, the ring buffer and internal feed channel capacity utilization, written to standard error like logs are.