### PR TITLE
docs: add roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ $ cat xcover_report.json | jq .cov_by_func
 89.9786897
 ```
 
+## Roadmap
+
+The following features and improvements are planned:
+
+- [ ] Add support for Go stripped binaries (#25)
+- [ ] Increase unit test coverage (#22)
+- [ ] Test commands (#21)
+- [ ] Move to upstream libbpfgo (#20)
+- [ ] Rename project to `maxcover` (#14)
+- [ ] Refactor status bar (#10)
+- [ ] Add version command (#9)
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

Added a Roadmap section to the README.md that provides visibility into planned features and improvements. The roadmap is based on open GitHub issues and formatted as an interactive checklist.

## Changes

- Added new "Roadmap" section between "Quickstart" and "Development" sections
- Included 7 open issues as checklist items with issue references
- Maintained consistent README formatting and sentence case style

## Roadmap Items

The following open issues are now tracked in the roadmap:

- #25: Add support for Go stripped binaries
- #22: Increase unit test coverage
- #21: Test commands
- #20: Move to upstream libbpfgo
- #14: Rename project to `maxcover`
- #10: Refactor status bar
- #9: Add version command

## Context

The roadmap section helps users and contributors understand the project's direction and planned enhancements. It's strategically placed after the Quickstart section to give readers a clear view of what's coming after they've learned the basics.

## Note

This PR is ready for review and should NOT be merged by the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)