### PR TITLE
ci: reinstate go vet in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,5 +168,8 @@ jobs:
             exit 1
           fi
 
+      - name: Run go vet
+        run: go vet ./...
+
       - name: Run go mod verify
         run: go mod verify


### PR DESCRIPTION
## Summary

This PR reinstates the `go vet` static analysis check in the CI workflow's lint job. PR #29 mentioned running go vet in its description, but the actual merged workflow did not include this check.

## Changes

- Added `go vet ./...` step to the lint job in `.github/workflows/ci.yml`
- Positioned between `go fmt` and `go mod verify` checks

## Verification

✅ `go vet ./...` passes locally with no issues
✅ All existing lint checks (go fmt, go mod verify) continue to work
✅ No code changes were needed - the codebase already passes go vet

## Why This Matters

`go vet` catches common Go programming errors including:
- Suspicious constructs
- Misuse of common patterns
- Potential bugs that the compiler doesn't catch
- Printf-style format string issues

Having this check in CI ensures code quality and prevents subtle bugs from being merged.

## Testing

The CI workflow will run automatically on this PR. All three jobs (Build, Test, Lint) should pass, with the new go vet check included in the Lint job.

Signed-off-by: Massimiliano Giovagnoli <maxgio92@pm.me>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)