### PR TITLE
fix: restore 'go vet' to CI workflow with libbpf 1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,14 +147,17 @@ jobs:
             libelf-dev \
             zlib1g-dev
 
-      - name: Install bpftool and libbpf
+      - name: Install libbpf 1.5.0
         run: |
-          git clone --depth 1 --branch v7.3.0 --recurse-submodules https://github.com/libbpf/bpftool.git /tmp/bpftool
-          # Install libbpf first to get newer headers
-          cd /tmp/bpftool/libbpf/src
+          # Install libbpf 1.5.0 which includes BPF_MAP_TYPE_ARENA support
+          git clone --depth 1 --branch v1.5.0 https://github.com/libbpf/libbpf.git /tmp/libbpf
+          cd /tmp/libbpf/src
           sudo make install
           sudo ldconfig
-          # Then install bpftool
+
+      - name: Install bpftool
+        run: |
+          git clone --depth 1 --branch v7.3.0 --recurse-submodules https://github.com/libbpf/bpftool.git /tmp/bpftool
           cd /tmp/bpftool/src
           make
           sudo make install
@@ -167,6 +170,14 @@ jobs:
             echo "$fmt_output"
             exit 1
           fi
+
+      - name: Run go vet
+        run: |
+          # Ensure CGO can find libbpf 1.5.0 headers
+          export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH}
+          export CGO_CFLAGS="-I/usr/local/include"
+          export CGO_LDFLAGS="-L/usr/local/lib64 -L/usr/local/lib"
+          go vet ./...
 
       - name: Run go mod verify
         run: go mod verify


### PR DESCRIPTION
## ⚠️ DO NOT MERGE - Requires Explicit Approval

This PR restores 'go vet' to the CI workflow and fixes the underlying BPF/CGO dependency issues.

## Summary

- ✅ Restore 'go vet' to `.github/workflows/ci.yml` lint job
- ✅ Install libbpf 1.5.0 for BPF_MAP_TYPE_ARENA support  
- ✅ Configure CGO flags to find libbpf 1.5.0 headers
- ✅ Verify go vet passes locally

## Changes

### libbpf Installation
- Install libbpf 1.5.0 directly from source (not from bpftool submodule)
- Provides BPF_MAP_TYPE_ARENA support required by libbpfgo dependency
- Install bpftool separately after libbpf

### go vet Configuration
- Set PKG_CONFIG_PATH to find libbpf 1.5.0 pkg-config files
- Set CGO_CFLAGS to include `/usr/local/include`
- Set CGO_LDFLAGS to include `/usr/local/lib64` and `/usr/local/lib`

## Root Cause

The libbpfgo dependency requires BPF_MAP_TYPE_ARENA which was not available in:
- System libbpf-dev packages (too old)
- libbpf from bpftool v7.3.0 submodule (older version)

Previous attempts to fix this included:
- Installing libbpf from bpftool submodule (still too old)
- Setting various CGO flags (headers not found)
- Disabling CGO (breaks BPF type checking)
- Removing go vet entirely (not ideal)

## Solution

Install libbpf 1.5.0 directly from the libbpf repository, which includes all modern BPF features including BPF_MAP_TYPE_ARENA.

## Testing

✅ `go vet ./...` passes locally
✅ All existing lint checks maintained (go fmt, go mod verify)

## Notes

This PR requires explicit approval before merging. Please review carefully and test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)