### PR TITLE
docs: add CI and release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # xcover
 
+[![CI](https://github.com/maxgio92/xcover/actions/workflows/ci.yml/badge.svg)](https://github.com/maxgio92/xcover/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/maxgio92/xcover)](https://github.com/maxgio92/xcover/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/maxgio92/xcover)](https://github.com/maxgio92/xcover/blob/main/go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/maxgio92/xcover)](https://goreportcard.com/report/github.com/maxgio92/xcover)
+
 Profile coverage of functional tests without instrumenting your binaries.
 
 `xcover` (pronounced 'cross cover') enables to profile functional test coverage, by leveraging kernel instrumentation to probe functions in userland, and it's cross language.


### PR DESCRIPTION
## Summary
Added status badges to README.md for better project visibility and information at a glance.

## Badges Added
- **CI Status**: Shows GitHub Actions workflow status
- **Latest Release**: Displays the current release version
- **License**: MIT License badge
- **Go Version**: Shows Go version from go.mod
- **Go Report Card**: Code quality metric for Go projects

## Details
The badges are placed at the top of the README, right after the title and before the project description, following standard README conventions. All badges use standard shields.io format and link to relevant resources.

## Testing
- Verified badge URLs are correct
- Ensured proper markdown formatting
- Badges render correctly in GitHub's README preview

---

**Note**: This PR is ready for review. Please review and merge manually when approved. DO NOT auto-merge.