### PR TITLE
docs: add CI and release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # xcover
 
+[![CI](https://github.com/maxgio92/xcover/actions/workflows/ci.yml/badge.svg)](https://github.com/maxgio92/xcover/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/maxgio92/xcover)](https://github.com/maxgio92/xcover/releases/latest)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 Profile coverage of functional tests without instrumenting your binaries.
 
 `xcover` (pronounced 'cross cover') enables to profile functional test coverage, by leveraging kernel instrumentation to probe functions in userland, and it's cross language.


### PR DESCRIPTION
## Summary

Added CI build status, latest release, and license badges to README.md for better visibility of project status.

## Changes

- Added CI/build status badge (GitHub Actions workflow)
- Added latest release badge (shields.io)
- Added MIT license badge (shields.io)
- Positioned badges at the top of README after the title

## Badges Added

1. **CI Status**: Shows the current build status from GitHub Actions
2. **Latest Release**: Links to the latest release version
3. **License**: Displays MIT license information

All badges follow standard GitHub/shields.io formatting and link to relevant pages.

---

Signed-off-by: Massimiliano Giovagnoli <maxgio92@pm.me>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>