### PR TITLE
ci: add GoReleaser for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.6'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            llvm \
+            libbpf-dev \
+            linux-headers-$(uname -r) \
+            gcc \
+            gcc-aarch64-linux-gnu \
+            make \
+            pkg-config \
+            libelf-dev \
+            zlib1g-dev
+
+      - name: Install bpftool and libbpf
+        run: |
+          git clone --depth 1 --branch v7.3.0 --recurse-submodules https://github.com/libbpf/bpftool.git /tmp/bpftool
+          # Install libbpf first to get newer headers
+          cd /tmp/bpftool/libbpf/src
+          sudo make install
+          sudo ldconfig
+          # Then install bpftool
+          cd /tmp/bpftool/src
+          make
+          sudo make install
+
+      - name: Verify bpftool installation
+        run: |
+          which bpftool
+          bpftool version
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: dist/*
+          retention-days: 30

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,143 @@
+# GoReleaser configuration for xcover
+# Reference: https://goreleaser.com
+
+version: 2
+
+before:
+  hooks:
+    # Initialize and update git submodules
+    - git submodule init
+    - git submodule update --recursive
+    # Build libbpfgo statically
+    - make -C libbpfgo libbpfgo-static
+    # Generate vmlinux.h if needed
+    - sh -c 'if [ ! -f bpf/vmlinux.h ]; then bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h; fi'
+    # Create output directory
+    - mkdir -p pkg/probe/output
+    # Compile BPF programs
+    - clang -D__TARGET_ARCH_x86 -g -O2 -c -target bpf -o pkg/probe/output/trace.bpf.o bpf/trace.bpf.c
+
+builds:
+  - id: xcover
+    binary: xcover
+    main: .
+    env:
+      - CGO_ENABLED=1
+      - CC=gcc
+    flags:
+      - -v
+    ldflags:
+      - -s -w
+      - -X github.com/maxgio92/xcover/pkg/cmd.version={{.Version}}
+      - -X github.com/maxgio92/xcover/pkg/cmd.commit={{.Commit}}
+      - -X github.com/maxgio92/xcover/pkg/cmd.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CGO_CFLAGS=-I {{ dir .Env.PWD }}/libbpfgo/output
+          - CGO_LDFLAGS=-lelf -lz {{ dir .Env.PWD }}/libbpfgo/output/libbpf/libbpf.a
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_CFLAGS=-I {{ dir .Env.PWD }}/libbpfgo/output
+          - CGO_LDFLAGS=-lelf -lz {{ dir .Env.PWD }}/libbpfgo/output/libbpf/libbpf.a
+          - CC=aarch64-linux-gnu-gcc
+
+archives:
+  - id: xcover
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+      - pkg/probe/output/trace.bpf.o
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: 'Performance Improvements'
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: 'CI/CD'
+      regexp: '^.*?ci(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: 'Other'
+      order: 999
+
+release:
+  github:
+    owner: maxgio92
+    name: xcover
+  draft: false
+  prerelease: auto
+  mode: append
+  header: |
+    ## xcover {{ .Tag }} ({{ .Date }})
+
+    Welcome to this new release of xcover!
+  footer: |
+    ## Installation
+
+    Download the appropriate binary for your system from the assets below.
+
+    ### Linux
+    ```bash
+    # AMD64
+    wget https://github.com/maxgio92/xcover/releases/download/{{ .Tag }}/xcover_{{ .Tag }}_linux_x86_64.tar.gz
+    tar -xzf xcover_{{ .Tag }}_linux_x86_64.tar.gz
+    sudo mv xcover /usr/local/bin/
+
+    # ARM64
+    wget https://github.com/maxgio92/xcover/releases/download/{{ .Tag }}/xcover_{{ .Tag }}_linux_arm64.tar.gz
+    tar -xzf xcover_{{ .Tag }}_linux_arm64.tar.gz
+    sudo mv xcover /usr/local/bin/
+    ```
+
+    ### Verify Installation
+    ```bash
+    xcover --version
+    ```
+
+    ## Notes
+
+    - xcover requires Linux kernel with BPF and BTF support (kernel 5.8+)
+    - Root privileges are required to run xcover
+    - The compiled BPF object (trace.bpf.o) is included in the archive
+  name_template: "{{.ProjectName}}-v{{.Version}}"


### PR DESCRIPTION
## Summary

This PR introduces GoReleaser for automated binary releases, enabling streamlined release management for xcover.

## Changes

### `.goreleaser.yml`
- **Multi-architecture builds**: Linux amd64 and arm64 support
- **BPF compilation**: Pre-build hooks to compile eBPF programs
- **Dependency management**: Automatic libbpfgo submodule initialization and build
- **CGO configuration**: Custom CFLAGS and LDFLAGS for libbpf static linking
- **Archive creation**: Includes LICENSE, README, and compiled BPF objects
- **Changelog generation**: Grouped by commit type (features, fixes, perf, ci)
- **GitHub Releases**: Automated release creation with formatted notes

### `.github/workflows/release.yml`
- **Trigger**: Activates on semver tags matching `v*.*.*` pattern
- **Dependencies**: Installs libbpf, bpftool, clang, and cross-compilation toolchain
- **GoReleaser**: Runs with GitHub token for release creation
- **Artifacts**: Uploads release assets with 30-day retention

## Implementation Details

### Build Process
1. Initialize git submodules (libbpfgo)
2. Build libbpfgo statically
3. Generate vmlinux.h if not present
4. Compile BPF programs with clang
5. Build Go binary with CGO and static libbpf linking
6. Create archives with binaries and BPF objects

### Supported Platforms
- **Linux amd64** (x86_64)
- **Linux arm64** (with cross-compilation)

Note: Only Linux is supported due to eBPF being a Linux-specific technology.

### Release Workflow
1. Tag a commit with semver format: `git tag -a v1.0.0 -m "Release v1.0.0"`
2. Push tag: `git push origin v1.0.0`
3. GitHub Actions automatically:
   - Builds binaries for all platforms
   - Generates checksums
   - Creates GitHub Release with changelog
   - Uploads all artifacts

## Testing

To test locally without creating a release:
```bash
goreleaser release --snapshot --clean
```

This will build binaries in the `dist/` directory without publishing.

## Requirements

- Kernel with BPF/BTF support (5.8+)
- libbpf development libraries
- bpftool
- clang/llvm

## Notes

- ⚠️ **DO NOT MERGE** - This PR requires manual review and approval before merging
- First release should be created after this PR is merged
- Archives include the compiled BPF object file (trace.bpf.o)
- Cross-compilation for ARM64 uses `aarch64-linux-gnu-gcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)