### PR TITLE
test(gopclntab): enhance tests and debug logging

### DIFF
--- a/pkg/trace/gopclntab.go
+++ b/pkg/trace/gopclntab.go
@@ -93,6 +93,12 @@ func (t *UserTracee) loadFunctionsFromGoPclntab() error {
 			Info:  byte(elf.STT_FUNC), // Mark as function type
 		}
 		elfSyms = append(elfSyms, sym)
+
+		t.logger.Debug().
+			Str("func", fn.Name).
+			Uint64("va", fn.Entry).
+			Uint64("file_offset", fileOffset).
+			Msg("converted VA to file offset")
 	}
 
 	// Filter symbols based on include/exclude patterns
@@ -127,10 +133,25 @@ func (t *UserTracee) loadFunctionsFromSymbols(funcSyms []elf.Symbol) error {
 		Msg("loading function offsets from symbols")
 
 	for _, sym := range funcSyms {
-		// Try to get the offset using the helper first (works for unstripped binaries)
+		// sym.Value should be a file offset
+		// - For normal ELF symbols, it's already a file offset
+		// - For symbols from .gopclntab, we convert VA to file offset before calling this function
 		offset := int64(sym.Value)
+
+		// Try to get the offset using the helper for validation/consistency,
+		// but fall back to sym.Value if it fails (which happens with stripped binaries)
 		if helperOffset, err := t.getSymbolOffset(sym.Name); err == nil {
 			offset = helperOffset
+			t.logger.Debug().
+				Str("symbol", sym.Name).
+				Int64("helper_offset", helperOffset).
+				Int64("sym_value", int64(sym.Value)).
+				Msg("using helper offset")
+		} else {
+			t.logger.Debug().
+				Str("symbol", sym.Name).
+				Int64("sym_value", int64(sym.Value)).
+				Msg("helper failed, using sym.Value as offset")
 		}
 
 		t.funcs[cookie(utils.Hash(sym.Name))] = funcInfo{

--- a/pkg/trace/gopclntab_test.go
+++ b/pkg/trace/gopclntab_test.go
@@ -13,7 +13,12 @@ import (
 )
 
 // TestLoadFunctionsFromGoPclntab tests that we can load function symbols
-// from the .gopclntab section of a stripped Go binary
+// from the .gopclntab section of a stripped Go binary.
+//
+// IMPORTANT: This test validates that offsets are correctly converted from
+// virtual addresses (VA) to file offsets. The .gopclntab section contains
+// function entry points as VAs, but uprobes require file offsets.
+// The conversion formula is: fileOffset = VA - textSection.Addr + textSection.Offset
 func TestLoadFunctionsFromGoPclntab(t *testing.T) {
 	// Create a temporary directory for test files
 	tmpDir, err := os.MkdirTemp("", "xcover-gopclntab-test-*")
@@ -153,6 +158,28 @@ func main() {
 		assert.True(t, foundHello, "should have found main.hello function in stripped binary")
 		assert.True(t, foundWorld, "should have found main.world function in stripped binary")
 		assert.True(t, foundGreet, "should have found main.greet function in stripped binary")
+
+		// Verify that offsets are file offsets, not virtual addresses.
+		// This validates the fix for the bug where VA was used directly instead of converting to file offset.
+		textSection := elfFile.Section(".text")
+		require.NotNil(t, textSection, "should have .text section")
+
+		for _, fn := range tracee.funcs {
+			if fn.name == "main.hello" || fn.name == "main.world" || fn.name == "main.greet" {
+				// File offsets should be much smaller than virtual addresses.
+				// For a typical Go binary, .text starts at VA ~0x400000+ but file offset ~0x1000.
+				// So a valid file offset should be less than 1MB for our small test binary.
+				assert.Less(t, fn.offset, uint64(1024*1024),
+					"offset for %s should be a file offset, not a VA (got 0x%x)", fn.name, fn.offset)
+
+				// Also verify offset is within reasonable range (after text section start)
+				assert.GreaterOrEqual(t, fn.offset, textSection.Offset,
+					"offset for %s should be >= .text section file offset", fn.name)
+
+				t.Logf("VALIDATED: %s has file offset 0x%x (within .text @ 0x%x, VA 0x%x)",
+					fn.name, fn.offset, textSection.Offset, textSection.Addr)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
This commit builds on top of PR #44 which fixed the VA to file offset
conversion bug for stripped Go binaries. It adds:

- Log each function's VA to file offset conversion during symbol loading
- Log when helper offset is used vs. sym.Value fallback
- Include both VA and file offset values for debugging

- Enhanced documentation in TestLoadFunctionsFromGoPclntab explaining
  the VA to file offset conversion and why it's critical
- Additional validation that offsets are file offsets, not VAs:
  * Check offsets are < 1MB (reasonable for test binary)
  * Verify offsets are >= .text section file offset
  * Log validated offsets with both file offset and VA for verification

- Improved comments in loadFunctionsFromSymbols explaining that sym.Value
  should be a file offset, with different handling for normal ELF symbols
  vs. symbols from .gopclntab

These improvements complement the existing TestGoPclntabOffsetCalculation
test from PR #44, adding inline validation to the main test and providing
better debugging output for troubleshooting stripped binary issues.

Related: #44

Signed-off-by: Massimiliano Giovagnoli <maxgio92@pm.me>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
