### PR TITLE
Release: ignore submodules in dirty state 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR ignores the submodules for consdiering the dirty state just before releasing with Goreleaser.
It also removes the `v` prefix in semver tags.