### PR TITLE
fix(trace): correct uprobe function identification (alignment, phantom entries, duplicate names)

### DIFF
--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"debug/elf"
 
-	"github.com/maxgio92/xcover/internal/utils"
 	"github.com/pkg/errors"
 )
 
@@ -60,8 +59,14 @@ func (t *UserTracee) Init(ctx context.Context) error {
 		}
 	}
 
+	// Key by file offset, which is unique per function location, rather than by
+	// a hash of the name. Distinct functions can share a name (C statics in
+	// different translation units, C++ overloads sharing a DWARF DW_AT_name),
+	// and name-keying would silently drop all but one of them. Functions that
+	// share an offset (weak aliases, identical-code folding) are genuinely the
+	// same code and collapse to a single entry.
 	for _, e := range entries {
-		t.funcs[cookie(utils.Hash(e.Name))] = funcInfo{
+		t.funcs[cookie(e.Offset)] = funcInfo{
 			name:   e.Name,
 			offset: e.Offset,
 		}

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -87,16 +87,41 @@ func (t *UserTracee) ShouldIncludeSymbol(sym elf.Symbol) bool {
 	return shouldInclude(sym, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
 }
 
+// GetFuncProbes returns the uprobe attach offsets and their corresponding
+// cookies, collected in a single pass over the function map so that offsets[i]
+// and cookies[i] always describe the same function.
+//
+// Callers attaching a uprobe_multi link (which consumes the offsets and cookies
+// as parallel arrays) must use this method. Pairing the results of
+// GetFuncOffsets and GetFuncCookies is unsafe: each ranges the map
+// independently and Go randomizes map iteration order, so the two slices may
+// describe the functions in different orders.
+func (t *UserTracee) GetFuncProbes() (offsets, cookies []uint64) {
+	offsets = make([]uint64, 0, len(t.funcs))
+	cookies = make([]uint64, 0, len(t.funcs))
+	for c, fn := range t.funcs {
+		offsets = append(offsets, fn.offset)
+		cookies = append(cookies, uint64(c))
+	}
+	return offsets, cookies
+}
+
+// GetFuncOffsets returns the attach offsets of all collected functions, in
+// unspecified order. To attach probes, use GetFuncProbes instead, which keeps
+// offsets and cookies aligned.
 func (t *UserTracee) GetFuncOffsets() []uint64 {
-	offsets := make([]uint64, len(t.funcs))
-	for i := range t.funcs {
-		offsets = append(offsets, t.funcs[i].offset)
+	offsets := make([]uint64, 0, len(t.funcs))
+	for c := range t.funcs {
+		offsets = append(offsets, t.funcs[c].offset)
 	}
 	return offsets
 }
 
+// GetFuncCookies returns the cookies of all collected functions, in unspecified
+// order. To attach probes, use GetFuncProbes instead, which keeps offsets and
+// cookies aligned.
 func (t *UserTracee) GetFuncCookies() []uint64 {
-	cookies := make([]uint64, len(t.funcs))
+	cookies := make([]uint64, 0, len(t.funcs))
 	for c := range t.funcs {
 		cookies = append(cookies, uint64(c))
 	}
@@ -104,9 +129,9 @@ func (t *UserTracee) GetFuncCookies() []uint64 {
 }
 
 func (t *UserTracee) GetFuncNames() []string {
-	names := make([]string, len(t.funcs))
-	for i := range t.funcs {
-		names = append(names, t.funcs[i].name)
+	names := make([]string, 0, len(t.funcs))
+	for c := range t.funcs {
+		names = append(names, t.funcs[c].name)
 	}
 	return names
 }

--- a/pkg/trace/tracee_probe_test.go
+++ b/pkg/trace/tracee_probe_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/maxgio92/xcover/internal/utils"
 	"github.com/maxgio92/xcover/pkg/trace"
 )
 
@@ -60,15 +59,54 @@ func TestUserTracee_GetFuncProbes_Alignment(t *testing.T) {
 	require.Len(t, offsets, len(probeTestEntries))
 	require.Len(t, cookies, len(probeTestEntries))
 
-	wantOffsetByCookie := make(map[uint64]uint64, len(probeTestEntries))
-	for _, e := range probeTestEntries {
-		wantOffsetByCookie[utils.Hash(e.Name)] = e.Offset
+	// The cookie reported when a probe fires must identify the function whose
+	// probe is attached at offsets[i]. Cookies are keyed by offset, so the
+	// alignment invariant is offsets[i] == cookies[i]; building the two slices
+	// from independent map ranges would break this.
+	for i := range cookies {
+		require.Equalf(t, offsets[i], cookies[i],
+			"offsets[%d]=%#x not aligned with cookies[%d]=%#x", i, offsets[i], i, cookies[i])
 	}
 
-	for i := range cookies {
-		wantOffset, ok := wantOffsetByCookie[cookies[i]]
-		require.Truef(t, ok, "unexpected cookie %d", cookies[i])
-		require.Equalf(t, wantOffset, offsets[i],
-			"cookie %d paired with offset %#x, want %#x", cookies[i], offsets[i], wantOffset)
+	// Every injected offset must be present exactly once.
+	want := make(map[uint64]int, len(probeTestEntries))
+	for _, e := range probeTestEntries {
+		want[e.Offset]++
+	}
+	got := make(map[uint64]int, len(offsets))
+	for _, o := range offsets {
+		got[o]++
+	}
+	require.Equal(t, want, got)
+}
+
+// TestUserTracee_DuplicateNames_NotDropped verifies that two distinct functions
+// sharing a name (e.g. C statics in different translation units, or C++
+// overloads sharing a DWARF DW_AT_name) are both traced. Keying probes by
+// name-hash collapses them into one map entry, silently dropping a function and
+// undercounting coverage.
+func TestUserTracee_DuplicateNames_NotDropped(t *testing.T) {
+	entries := []trace.FunctionEntry{
+		{Name: "helper", Offset: 0x1160},
+		{Name: "helper", Offset: 0x11a0}, // same name, different function
+		{Name: "unique", Offset: 0x1200},
+	}
+	tracee := trace.NewUserTracee(
+		trace.WithTraceeExePath("dummy-path"),
+		trace.WithTraceeResolver(staticResolver(entries)),
+		trace.WithTraceeLogger(testLogger),
+	)
+	require.NoError(t, tracee.Init(t.Context()))
+
+	offsets, cookies := tracee.GetFuncProbes()
+	require.Len(t, offsets, len(entries), "a duplicate-named function was dropped")
+	require.Len(t, cookies, len(entries))
+
+	gotOffset := make(map[uint64]bool, len(offsets))
+	for _, o := range offsets {
+		gotOffset[o] = true
+	}
+	for _, e := range entries {
+		require.Truef(t, gotOffset[e.Offset], "offset %#x for %q missing", e.Offset, e.Name)
 	}
 }

--- a/pkg/trace/tracee_probe_test.go
+++ b/pkg/trace/tracee_probe_test.go
@@ -1,0 +1,74 @@
+package trace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/maxgio92/xcover/internal/utils"
+	"github.com/maxgio92/xcover/pkg/trace"
+)
+
+// staticResolver returns a fixed set of entries without opening any binary.
+func staticResolver(entries []trace.FunctionEntry) trace.FunctionResolver {
+	return func(_ context.Context) ([]trace.FunctionEntry, error) {
+		return entries, nil
+	}
+}
+
+var probeTestEntries = []trace.FunctionEntry{
+	{Name: "pkg.Alpha", Offset: 0x1000},
+	{Name: "pkg.Beta", Offset: 0x2000},
+	{Name: "pkg.Gamma", Offset: 0x3000},
+}
+
+func newProbeTestTracee(t *testing.T) *trace.UserTracee {
+	t.Helper()
+	tracee := trace.NewUserTracee(
+		trace.WithTraceeExePath("dummy-path"),
+		trace.WithTraceeResolver(staticResolver(probeTestEntries)),
+		trace.WithTraceeLogger(testLogger),
+	)
+	require.NoError(t, tracee.Init(t.Context()))
+	return tracee
+}
+
+// TestUserTracee_GetterLengths asserts the getters return exactly one element
+// per resolved function. The previous implementation pre-sized the slices with
+// make([]T, len(funcs)) and then appended, yielding 2N elements whose first N
+// were zero/empty values.
+func TestUserTracee_GetterLengths(t *testing.T) {
+	tracee := newProbeTestTracee(t)
+	n := len(probeTestEntries)
+
+	require.Len(t, tracee.GetFuncOffsets(), n, "offsets slice has phantom entries")
+	require.Len(t, tracee.GetFuncCookies(), n, "cookies slice has phantom entries")
+	require.Len(t, tracee.GetFuncNames(), n, "names slice has phantom entries")
+}
+
+// TestUserTracee_GetFuncProbes_Alignment asserts that offsets and cookies are
+// index-aligned: offsets[i] is the offset of the function identified by
+// cookies[i]. The previous code derived offsets and cookies from two
+// independent range loops over a map; Go randomizes map iteration order, so the
+// two slices could describe functions in different orders, attaching a uprobe
+// at one function's offset under another function's cookie.
+func TestUserTracee_GetFuncProbes_Alignment(t *testing.T) {
+	tracee := newProbeTestTracee(t)
+
+	offsets, cookies := tracee.GetFuncProbes()
+	require.Len(t, offsets, len(probeTestEntries))
+	require.Len(t, cookies, len(probeTestEntries))
+
+	wantOffsetByCookie := make(map[uint64]uint64, len(probeTestEntries))
+	for _, e := range probeTestEntries {
+		wantOffsetByCookie[utils.Hash(e.Name)] = e.Offset
+	}
+
+	for i := range cookies {
+		wantOffset, ok := wantOffsetByCookie[cookies[i]]
+		require.Truef(t, ok, "unexpected cookie %d", cookies[i])
+		require.Equalf(t, wantOffset, offsets[i],
+			"cookie %d paired with offset %#x, want %#x", cookies[i], offsets[i], wantOffset)
+	}
+}

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -177,8 +177,7 @@ func (t *UserTracer) Run(ctx context.Context) error {
 func (t *UserTracer) attachProbe(ctx context.Context) {
 	batchSize := bpfUprobeMultiAttachMaxOffsets
 
-	offsets := t.tracee.GetFuncOffsets()
-	cookies := t.tracee.GetFuncCookies()
+	offsets, cookies := t.tracee.GetFuncProbes()
 
 	for i := 0; i < len(offsets); i += batchSize {
 		end := i + batchSize


### PR DESCRIPTION
## Summary

`UserTracee`'s probe accessors have two bugs:

1. **Phantom entries.** `GetFuncOffsets`, `GetFuncCookies` and `GetFuncNames` allocate with `make([]T, len(funcs))` and then `append`, producing slices of length **2N** whose first N elements are zero/empty. These spurious leading `(offset 0, cookie 0)` entries are submitted to the attach call. (I have not verified the kernel's handling of an offset-0 attach at runtime — attaching uprobes needs `CAP_BPF`, which I don't have in this environment — so I'm only claiming they are *submitted*, not what the kernel does with them.)

2. **Offset/cookie misalignment (the serious one).** `attachProbe()` builds the offset and cookie slices from two *separate* calls:
   ```go
   offsets := t.tracee.GetFuncOffsets()
   cookies := t.tracee.GetFuncCookies()
   ```
   Each ranges the `funcs` map independently, and Go randomizes map iteration order, so `offsets[i]` and `cookies[i]` can describe **different** functions.

   This matters because libbpf consumes the two as **parallel arrays indexed by the same counter** — `struct bpf_uprobe_multi_opts { ... offsets; ... cookies; ... cnt; }` (confirmed in the vendored `libbpf.h`), and libbpfgo passes `&offsets[0]`/`&cookies[0]` with a single length (`prog.go` `doAttachUprobeMulti`). The BPF program reports the attach cookie as the function identifier (`bpf/trace.bpf.c`: `cookie = bpf_get_attach_cookie(ctx)` → `event->cookie`), which userspace maps back via `t.tracee.funcs[event.Cookie]` (`tracer.go`). So a uprobe placed at function A's offset can fire and be reported under function B's cookie — **misattributing coverage to the wrong function**, nondeterministically per run (when the two map iterations happen to agree, a run is unaffected).

## Fix

- Pre-size the getter slices with `make([]T, 0, len(funcs))`.
- Add `GetFuncProbes()`, which builds offsets and cookies in a **single** map pass so they stay index-aligned, and use it in `attachProbe()`.
- Document `GetFuncOffsets`/`GetFuncCookies` as unordered and unsafe to pair.

## Tests

- `TestUserTracee_GetterLengths` — asserts one element per function (fails on `main` with `6 != 3`).
- `TestUserTracee_GetFuncProbes_Alignment` — asserts `offsets[i]` is the offset of the function identified by `cookies[i]`.

Both new tests plus the existing `pkg/trace` unit suite pass locally (`gofmt`/`go vet` clean).

**Caveats / not verified:**
- The runtime effect of the offset-0 entries (see above) — no `CAP_BPF` in my environment.
- `TestRecoveryResolver` (integration) fails on my machine on **unmodified `main`** too: it `assert.Len(entries, 4)` for a stripped C binary, but resurgo finds 5 `.eh_frame` functions with the local toolchain. Unrelated to this change.

Opening as a **draft** for maintainer feedback on the approach (in particular, keeping vs. removing the now-unpaired `GetFuncOffsets`/`GetFuncCookies` accessors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)