### PR TITLE
feat(trace): --debug-path to trace stripped binaries via a separate debug file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `xcover` (pronounced "cross cover") revolutionizes functional test coverage profiling by leveraging kernel instrumentation to probe userland functions. This cross-language approach measures coverage directly from ELF binaries, eliminating the need for ecosystem-specific tools like [Go cover](https://go.dev/doc/build-cover) or [LLVM cov](https://llvm.org/docs/CommandGuide/llvm-cov.html).
 
-[![asciicast](https://asciinema.org/a/jCznrMDudxznMTid.svg)](https://asciinema.org/a/jCznrMDudxznMTid)
+[![asciicast](https://asciinema.org/a/GyzGzTTEP63GJzAG.svg)](https://asciinema.org/a/GyzGzTTEP63GJzAG)
 
 ## Quickstart
 
@@ -93,6 +93,16 @@ The Go symbolization fallback:
 - Supports Go 1.2+ binaries
 - Maintains full compatibility with symbol filtering
 - Requires no additional configuration
+
+#### Other binaries (separate debug file)
+
+For stripped non-Go binaries, point `--debug-path` at a matching debug file (e.g. `objcopy --only-keep-debug` output, or a distro `-dbg`/debuginfod artifact) to recover real function names from its `.symtab` (or DWARF):
+
+```shell
+$ xcover run --path ./app --debug-path ./app.debug
+```
+
+Names come from `--debug-path`; uprobe offsets are computed against `--path`. The two are matched by GNU build-id — pass `--no-build-id-check` for toolchains that omit it.
 
 ## Daemon Mode
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -94,6 +94,16 @@ The Go symbolization fallback:
 - Maintains full compatibility with symbol filtering
 - Requires no additional configuration
 
+#### Other binaries (separate debug file)
+
+For stripped non-Go binaries, point `--debug-path` at a matching debug file (e.g. `objcopy --only-keep-debug` output, or a distro `-dbg`/debuginfod artifact) to recover real function names from its `.symtab` (or DWARF):
+
+```shell
+$ xcover run --path ./app --debug-path ./app.debug
+```
+
+Names come from `--debug-path`; uprobe offsets are computed against `--path`. The two are matched by GNU build-id — pass `--no-build-id-check` for toolchains that omit it.
+
 ## Daemon Mode
 
 Run xcover as a background daemon for flexible test execution. This mode enables you to start the profiler, run multiple test suites, and collect results when complete.

--- a/docs/xcover_run.md
+++ b/docs/xcover_run.md
@@ -16,15 +16,17 @@ xcover run [flags]
 ### Options
 
 ```
-  -d, --detach           Run xcover as daemon
-      --exclude string   Regex pattern to exclude function symbol names
-  -h, --help             help for run
-      --include string   Regex pattern to include function symbol names
-  -p, --path string      Path to the ELF executable
-      --pid int          Filter the process by PID (default -1)
-      --report           Generate report (as xcover-report.json) (default true)
-      --status           Periodically print a status of the trace (default true)
-      --verbose          Enable verbosity
+      --debug-path string   Path to a separate debug/symbol file (e.g. objcopy --only-keep-debug output) to resolve function names for a stripped --path binary
+  -d, --detach              Run xcover as daemon
+      --exclude string      Regex pattern to exclude function symbol names
+  -h, --help                help for run
+      --include string      Regex pattern to include function symbol names
+      --no-build-id-check   Skip GNU build-id verification between --path and --debug-path
+  -p, --path string         Path to the ELF executable
+      --pid int             Filter the process by PID (default -1)
+      --report              Generate report (as xcover-report.json) (default true)
+      --status              Periodically print a status of the trace (default true)
+      --verbose             Enable verbosity
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -33,6 +33,9 @@ type Options struct {
 	symExcludePattern string
 	symIncludePattern string
 
+	debugPath      string
+	noBuildIDCheck bool
+
 	detach  bool
 	verbose bool
 	report  bool
@@ -60,6 +63,9 @@ It supports programs compiled to ELF.
 
 	cmd.Flags().StringVar(&o.symExcludePattern, "exclude", "", "Regex pattern to exclude function symbol names")
 	cmd.Flags().StringVar(&o.symIncludePattern, "include", "", "Regex pattern to include function symbol names")
+
+	cmd.Flags().StringVar(&o.debugPath, "debug-path", "", "Path to a separate debug/symbol file (e.g. objcopy --only-keep-debug output) to resolve function names for a stripped --path binary")
+	cmd.Flags().BoolVar(&o.noBuildIDCheck, "no-build-id-check", false, "Skip GNU build-id verification between --path and --debug-path")
 
 	cmd.Flags().BoolVarP(&o.detach, "detach", "d", false, fmt.Sprintf("Run %s as daemon", settings.CmdName))
 	cmd.Flags().BoolVar(&o.verbose, "verbose", false, "Enable verbosity")
@@ -92,12 +98,21 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	}
 	o.Logger = o.Logger.Level(logLevel)
 
-	tracee := trace.NewUserTracee(
+	traceeOpts := []trace.UserTraceeOption{
 		trace.WithTraceeExePath(o.comm),
 		trace.WithTraceeSymPatternInclude(o.symIncludePattern),
 		trace.WithTraceeSymPatternExclude(o.symExcludePattern),
 		trace.WithTraceeLogger(o.Logger),
-	)
+	}
+	if o.debugPath != "" {
+		// Resolve names/addresses from the companion debug file while computing
+		// uprobe offsets against the (stripped) executable at --path.
+		traceeOpts = append(traceeOpts, trace.WithTraceeResolver(
+			trace.SeparateDebugResolver(o.comm, o.debugPath, o.Logger,
+				o.symIncludePattern, o.symExcludePattern, nil, nil, o.noBuildIDCheck),
+		))
+	}
+	tracee := trace.NewUserTracee(traceeOpts...)
 
 	tracer := trace.NewUserTracer(
 		trace.WithTracerLogger(o.Logger),
@@ -132,6 +147,12 @@ func (o *Options) daemonize() error {
 	args = append(args, fmt.Sprintf("--report=%s", strconv.FormatBool(o.report)))
 	args = append(args, fmt.Sprintf("--status=%s", strconv.FormatBool(o.status)))
 	args = append(args, fmt.Sprintf("--verbose=%s", strconv.FormatBool(o.verbose)))
+	if o.debugPath != "" {
+		args = append(args, fmt.Sprintf("--debug-path=%s", o.debugPath))
+	}
+	if o.noBuildIDCheck {
+		args = append(args, "--no-build-id-check")
+	}
 
 	cmd := exec.Command(os.Args[0], args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/pkg/trace/resolver_debug.go
+++ b/pkg/trace/resolver_debug.go
@@ -1,0 +1,311 @@
+package trace
+
+import (
+	"bytes"
+	"context"
+	"debug/dwarf"
+	"debug/elf"
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+	log "github.com/rs/zerolog"
+)
+
+// ntGNUBuildID is the ELF note type for a GNU build-id (NT_GNU_BUILD_ID).
+const ntGNUBuildID = 3
+
+// SeparateDebugResolver returns a FunctionResolver that reads function symbols
+// from a companion debug file (e.g. `objcopy --only-keep-debug` output, a
+// distro -dbg package, or a debuginfod artifact) while computing uprobe attach
+// offsets against the executable that is actually mmap'd at runtime.
+//
+// Symbols come from the debug file's .symtab (primary) or DWARF subprograms
+// (fallback). Offsets are computed from the executable's PT_LOAD program
+// headers: function virtual addresses are identical in both files because they
+// come from the same link, and program headers survive even section-table
+// stripping (e.g. `eu-strip --strip-sections`) where .symtab/.dynsym/.eh_frame
+// are gone and no other resolver can work.
+//
+// build-id verification (read from PT_NOTE, so it works on section-stripped
+// executables) guards against pairing a debug file with the wrong executable.
+// Unless skipBuildID is set, a missing or mismatched build-id fails resolution.
+//
+// On failure the returned error is deliberately NOT wrapped in ErrNoSymbolTable,
+// so UserTracee.Init surfaces it instead of silently falling back to binary
+// recovery: when the user explicitly supplies a debug file, a problem with it
+// should be reported, not papered over with synthetic func_0x<addr> names.
+func SeparateDebugResolver(exePath, debugPath string, logger log.Logger, include, exclude string, bindInclude, bindExclude []elf.SymBind, skipBuildID bool) FunctionResolver {
+	return func(ctx context.Context) ([]FunctionEntry, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		exe, err := elf.Open(exePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to open executable")
+		}
+		defer exe.Close()
+
+		dbg, err := elf.Open(debugPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to open debug file")
+		}
+		defer dbg.Close()
+
+		if err := verifyBuildIDMatch(exe, dbg, skipBuildID, logger); err != nil {
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// Offsets always come from the executable, never the debug file: the
+		// debug file's loadable sections are SHT_NOBITS and its file offsets are
+		// meaningless, but its symbol values are the (shared) virtual addresses.
+		toOffset := func(va uint64) (uint64, error) { return vaToFileOffset(exe, va) }
+
+		// Primary: the debug file's .symtab (retained by --only-keep-debug and
+		// `eu-strip -f`). Names here are already linkage-level and unambiguous.
+		syms, err := funcSymsFromELF(dbg, include, exclude, bindInclude, bindExclude)
+		if err == nil {
+			if syms = definedFuncs(syms); len(syms) > 0 {
+				logger.Info().Int("symbols", len(syms)).Msg("resolved functions from debug file .symtab")
+				return funcEntriesFromSymbols(syms, toOffset, logger)
+			}
+		}
+
+		// Fallback: DWARF subprograms. Best-effort — see funcSymsFromDWARF.
+		logger.Info().Msg("debug file has no usable .symtab; trying DWARF subprograms")
+		dwarfSyms, derr := funcSymsFromDWARF(dbg, include, exclude, logger)
+		if derr != nil {
+			return nil, errors.Wrapf(derr, "no usable symbols in debug file %q (.symtab and DWARF both failed)", debugPath)
+		}
+		if dwarfSyms = definedFuncs(dwarfSyms); len(dwarfSyms) == 0 {
+			return nil, errors.Errorf("no defined functions in debug file %q", debugPath)
+		}
+		return funcEntriesFromSymbols(dwarfSyms, toOffset, logger)
+	}
+}
+
+// definedFuncs drops undefined and zero-address symbols. Imported functions
+// (e.g. printf) appear in .symtab as STT_FUNC with SHN_UNDEF and Value==0; on a
+// PIE the first PT_LOAD has Vaddr 0, so VA 0 maps to file offset 0 (the ELF
+// header) instead of being rejected, which would attach a bogus probe.
+func definedFuncs(syms []elf.Symbol) []elf.Symbol {
+	out := make([]elf.Symbol, 0, len(syms))
+	for _, s := range syms {
+		if s.Section == elf.SHN_UNDEF || s.Value == 0 {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// dwarfSubprogram holds the name attributes of a DW_TAG_subprogram DIE, plus a
+// reference to follow when the name lives on another DIE.
+type dwarfSubprogram struct {
+	name    string
+	linkage string
+	ref     dwarf.Offset // DW_AT_specification / DW_AT_abstract_origin target
+	hasRef  bool
+}
+
+// funcSymsFromDWARF extracts function entries from DWARF .debug_info as a
+// fallback when the debug file has no .symtab.
+//
+// Only subprograms with a code address are emitted (declarations and
+// abstract/inlined instances are skipped). The entry address follows DWARF 5
+// (§2.18, §3.3.5): DW_AT_entry_pc, else DW_AT_low_pc, else the first
+// DW_AT_ranges entry. DW_AT_linkage_name is preferred
+// over DW_AT_name so C++ overloads stay distinct. For C++ member and namespaced
+// functions the definition DIE carries DW_AT_low_pc but its name only via a
+// DW_AT_specification/DW_AT_abstract_origin reference to the declaration, so
+// those references are followed (a pre-pass indexes DIE names by offset).
+//
+// Known limitations (both reasons .symtab — retained by --only-keep-debug and
+// `eu-strip -f` — is the primary, far more robust source):
+//   - split-DWARF (-gsplit-dwarf) keeps subprogram DIEs in separate .dwo files
+//     not present here, so few functions resolve.
+//   - debug files that move data into a supplementary object file — dwz's
+//     default GNU extension (.gnu_debugaltlink, DW_FORM_GNU_ref_alt/strp_alt)
+//     or the DWARF 5 standard equivalent (.debug_sup, DW_FORM_ref_sup4/8 and
+//     strp_sup; §7.3.6) — reference names cross-file. Go's debug/dwarf decodes
+//     these forms to raw offsets but never loads the supplementary file, so
+//     such names resolve empty and are skipped. Common on Fedora/Debian
+//     debuginfod, which dwz-process their debug files.
+func funcSymsFromDWARF(f *elf.File, include, exclude string, logger log.Logger) ([]elf.Symbol, error) {
+	d, err := f.DWARF()
+	if err != nil {
+		return nil, errors.Wrap(err, "no DWARF info")
+	}
+	if f.Section(".gnu_debugaltlink") != nil {
+		logger.Warn().Msg("debug file uses a dwz supplementary file (.gnu_debugaltlink); names referenced via DW_FORM_GNU_ref_alt cannot be resolved and will be skipped")
+	}
+
+	// Pre-pass: index every subprogram DIE's names by offset so references can
+	// be resolved.
+	byOffset := map[dwarf.Offset]dwarfSubprogram{}
+	r := d.Reader()
+	for {
+		entry, err := r.Next()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading DWARF")
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		sp := dwarfSubprogram{}
+		sp.name, _ = entry.Val(dwarf.AttrName).(string)
+		sp.linkage, _ = entry.Val(dwarf.AttrLinkageName).(string)
+		if off, ok := entry.Val(dwarf.AttrSpecification).(dwarf.Offset); ok {
+			sp.ref, sp.hasRef = off, true
+		} else if off, ok := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset); ok {
+			sp.ref, sp.hasRef = off, true
+		}
+		byOffset[entry.Offset] = sp
+	}
+
+	// resolveName follows specification/abstract_origin references (bounded) to
+	// find a linkage or plain name.
+	resolveName := func(sp dwarfSubprogram) string {
+		for hops := 0; hops < 8; hops++ {
+			if sp.linkage != "" {
+				return sp.linkage
+			}
+			if sp.name != "" {
+				return sp.name
+			}
+			if !sp.hasRef {
+				return ""
+			}
+			next, ok := byOffset[sp.ref]
+			if !ok {
+				return ""
+			}
+			sp = next
+		}
+		return ""
+	}
+
+	var syms []elf.Symbol
+	r = d.Reader()
+	for {
+		entry, err := r.Next()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading DWARF")
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		// Entry address per DWARF 5 (§2.18, §3.3.5): prefer DW_AT_entry_pc;
+		// otherwise DW_AT_low_pc (which for a non-contiguous function may be a
+		// base address rather than the entry); otherwise the first DW_AT_ranges
+		// entry. A subprogram with none of these is a declaration/abstract
+		// instance with no code, and is skipped.
+		addr, ok := entry.Val(dwarf.AttrEntrypc).(uint64)
+		if !ok || addr == 0 {
+			addr, ok = entry.Val(dwarf.AttrLowpc).(uint64)
+		}
+		if !ok || addr == 0 {
+			if rs, rerr := d.Ranges(entry); rerr == nil && len(rs) > 0 {
+				addr = rs[0][0]
+			}
+		}
+		if addr == 0 {
+			continue
+		}
+		name := resolveName(byOffset[entry.Offset])
+		if name == "" {
+			continue
+		}
+		sym := elf.Symbol{Name: name, Value: addr, Info: byte(elf.STT_FUNC)}
+		if shouldInclude(sym, include, exclude, nil, nil) {
+			syms = append(syms, sym)
+		}
+	}
+	if len(syms) == 0 {
+		return nil, errors.New("no DWARF subprograms with a concrete low_pc")
+	}
+	logger.Info().Int("subprograms", len(syms)).Msg("resolved functions from DWARF")
+	return syms, nil
+}
+
+// verifyBuildIDMatch fails unless the executable and debug file carry the same
+// GNU build-id. The id is read from PT_NOTE program headers rather than the
+// .note.gnu.build-id section so that verification still works on executables
+// whose section table has been stripped.
+func verifyBuildIDMatch(exe, dbg *elf.File, skip bool, logger log.Logger) error {
+	if skip {
+		logger.Warn().Msg("build-id verification disabled (--no-build-id-check)")
+		return nil
+	}
+	exeID := buildID(exe)
+	dbgID := buildID(dbg)
+	if len(exeID) == 0 || len(dbgID) == 0 {
+		return errors.Wrap(ErrNoBuildID, "cannot verify the debug file belongs to the executable; pass --no-build-id-check to bypass")
+	}
+	if !bytes.Equal(exeID, dbgID) {
+		return errors.Wrapf(ErrDebugBuildIDMismatch, "executable=%x debug=%x", exeID, dbgID)
+	}
+	logger.Debug().Hex("build_id", exeID).Msg("debug file build-id matches executable")
+	return nil
+}
+
+// buildID returns the GNU build-id from the first PT_NOTE segment that contains
+// one, or nil if absent. Reading from the program header (not the section)
+// means it survives section-table stripping.
+func buildID(f *elf.File) []byte {
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_NOTE {
+			continue
+		}
+		data := make([]byte, p.Filesz)
+		if _, err := p.ReadAt(data, 0); err != nil {
+			continue
+		}
+		if id := parseBuildIDNote(data, f.ByteOrder); id != nil {
+			return id
+		}
+	}
+	return nil
+}
+
+// parseBuildIDNote scans a PT_NOTE payload for an NT_GNU_BUILD_ID note and
+// returns its descriptor (the build-id bytes), or nil.
+func parseBuildIDNote(data []byte, bo binary.ByteOrder) []byte {
+	r := bytes.NewReader(data)
+	for r.Len() >= 12 {
+		var namesz, descsz, ntype uint32
+		if err := binary.Read(r, bo, &namesz); err != nil {
+			return nil
+		}
+		if err := binary.Read(r, bo, &descsz); err != nil {
+			return nil
+		}
+		if err := binary.Read(r, bo, &ntype); err != nil {
+			return nil
+		}
+		name := make([]byte, align4(namesz))
+		if _, err := r.Read(name); err != nil {
+			return nil
+		}
+		desc := make([]byte, align4(descsz))
+		if _, err := r.Read(desc); err != nil {
+			return nil
+		}
+		if ntype == ntGNUBuildID && namesz >= 3 && string(name[:3]) == "GNU" {
+			return desc[:descsz]
+		}
+	}
+	return nil
+}
+
+// align4 rounds n up to the next 4-byte boundary (ELF note fields are padded).
+func align4(n uint32) uint32 { return (n + 3) &^ 3 }

--- a/pkg/trace/resolver_debug_integration_test.go
+++ b/pkg/trace/resolver_debug_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package trace_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/maxgio92/xcover/pkg/trace"
+)
+
+const debugFixtureSrc = `
+#include <stdio.h>
+__attribute__((noinline)) void alpha(void){ printf("a\n"); }
+__attribute__((noinline)) void beta(void){ printf("b\n"); }
+int main(void){ alpha(); beta(); return 0; }
+`
+
+// buildDebugFixture compiles src as a PIE with debug info, then derives a
+// separate debug file (objcopy --only-keep-debug) and a fully stripped binary.
+// Extra gcc args may be appended (e.g. -Wl,--build-id=none).
+func buildDebugFixture(t *testing.T, dir, name, src string, extraGCC ...string) (exe, dbg, stripped string) {
+	t.Helper()
+	srcPath := filepath.Join(dir, name+".c")
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0o644))
+
+	exe = filepath.Join(dir, name)
+	args := append([]string{"-O2", "-g", "-fPIE", "-pie", "-o", exe, srcPath}, extraGCC...)
+	if out, err := exec.Command("gcc", args...).CombinedOutput(); err != nil {
+		t.Skipf("gcc unavailable or failed: %v: %s", err, out)
+	}
+
+	dbg = exe + ".debug"
+	out, err := exec.Command("objcopy", "--only-keep-debug", exe, dbg).CombinedOutput()
+	require.NoErrorf(t, err, "objcopy --only-keep-debug: %s", out)
+
+	stripped = exe + ".stripped"
+	require.NoError(t, debugCopyFile(stripped, exe))
+	out, err = exec.Command("strip", "--strip-all", stripped).CombinedOutput()
+	require.NoErrorf(t, err, "strip: %s", out)
+	return exe, dbg, stripped
+}
+
+func debugCopyFile(dst, src string) error {
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, b, 0o755)
+}
+
+func nameOffsets(t *testing.T, r trace.FunctionResolver) map[string]uint64 {
+	t.Helper()
+	entries, err := r(t.Context())
+	require.NoError(t, err)
+	m := make(map[string]uint64, len(entries))
+	for _, e := range entries {
+		m[e.Name] = e.Offset
+	}
+	return m
+}
+
+// TestSeparateDebugResolver_SymtabEquivalence is the core guarantee: resolving a
+// stripped binary via its companion debug file yields exactly the same
+// name->offset mapping as resolving the unstripped binary directly.
+func TestSeparateDebugResolver_SymtabEquivalence(t *testing.T) {
+	dir := t.TempDir()
+	exe, dbg, stripped := buildDebugFixture(t, dir, "equiv", debugFixtureSrc)
+
+	want := nameOffsets(t, trace.SymbolTableResolver(exe, testLogger, `^(alpha|beta|main)$`, "", nil, nil))
+	got := nameOffsets(t, trace.SeparateDebugResolver(stripped, dbg, testLogger, `^(alpha|beta|main)$`, "", nil, nil, false))
+
+	require.Len(t, got, 3)
+	require.Equal(t, want, got)
+}
+
+// TestSeparateDebugResolver_BuildIDMismatch rejects a debug file that belongs to
+// a different build.
+func TestSeparateDebugResolver_BuildIDMismatch(t *testing.T) {
+	dir := t.TempDir()
+	_, _, stripped := buildDebugFixture(t, dir, "a", debugFixtureSrc)
+	_, otherDbg, _ := buildDebugFixture(t, dir, "b", debugFixtureSrc+"\nint extra(void){return 7;}\n")
+
+	_, err := trace.SeparateDebugResolver(stripped, otherDbg, testLogger, "", "", nil, nil, false)(t.Context())
+	require.ErrorIs(t, err, trace.ErrDebugBuildIDMismatch)
+}
+
+// TestSeparateDebugResolver_NoBuildID fails closed when build-ids are absent,
+// and proceeds when verification is explicitly disabled.
+func TestSeparateDebugResolver_NoBuildID(t *testing.T) {
+	dir := t.TempDir()
+	_, dbg, stripped := buildDebugFixture(t, dir, "nobid", debugFixtureSrc, "-Wl,--build-id=none")
+
+	_, err := trace.SeparateDebugResolver(stripped, dbg, testLogger, "", "", nil, nil, false)(t.Context())
+	require.ErrorIs(t, err, trace.ErrNoBuildID)
+
+	got := nameOffsets(t, trace.SeparateDebugResolver(stripped, dbg, testLogger, `^(alpha|beta|main)$`, "", nil, nil, true))
+	require.Len(t, got, 3)
+}
+
+// TestSeparateDebugResolver_FiltersUndefined ensures imported/zero-address
+// symbols are dropped (no probe at file offset 0 on a PIE).
+func TestSeparateDebugResolver_FiltersUndefined(t *testing.T) {
+	dir := t.TempDir()
+	_, dbg, stripped := buildDebugFixture(t, dir, "undef", debugFixtureSrc)
+
+	entries, err := trace.SeparateDebugResolver(stripped, dbg, testLogger, "", "", nil, nil, false)(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, e := range entries {
+		require.NotZerof(t, e.Offset, "function %q resolved to offset 0", e.Name)
+		require.NotContainsf(t, e.Name, "printf", "imported symbol %q leaked", e.Name)
+	}
+}
+
+// TestSeparateDebugResolver_DWARFFallback resolves via DWARF subprograms when
+// the debug file has no .symtab.
+func TestSeparateDebugResolver_DWARFFallback(t *testing.T) {
+	dir := t.TempDir()
+	_, dbg, stripped := buildDebugFixture(t, dir, "dw", debugFixtureSrc)
+
+	out, err := exec.Command("objcopy", "--remove-section=.symtab", "--remove-section=.strtab", dbg, dbg).CombinedOutput()
+	require.NoErrorf(t, err, "objcopy --remove-section: %s", out)
+
+	got := nameOffsets(t, trace.SeparateDebugResolver(stripped, dbg, testLogger, `^(alpha|beta|main)$`, "", nil, nil, false))
+	require.Contains(t, got, "alpha")
+	require.Contains(t, got, "beta")
+	require.Contains(t, got, "main")
+}
+
+// TestSeparateDebugResolver_DWARFCppMembers verifies the DWARF fallback resolves
+// C++ member and namespaced functions, whose definition DIE carries low_pc but
+// gets its name only via a DW_AT_specification reference, and disambiguates
+// overloads via DW_AT_linkage_name.
+func TestSeparateDebugResolver_DWARFCppMembers(t *testing.T) {
+	if _, err := exec.LookPath("g++"); err != nil {
+		t.Skip("g++ not available")
+	}
+	dir := t.TempDir()
+	src := `
+#include <cstdio>
+namespace ns { int helper(int x){ return x+1; } }
+struct Widget { int method(int x){ return x*2; } };
+int foo(int x){ return x+1; }
+double foo(double x){ return x+0.5; }
+int main(){ Widget w; volatile int s = ns::helper(1)+w.method(2)+foo(3)+(int)foo(4.0); printf("%d\n", s); return 0; }
+`
+	srcPath := filepath.Join(dir, "cpp.cpp")
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0o644))
+	exe := filepath.Join(dir, "cpp")
+	if out, err := exec.Command("g++", "-O0", "-g", "-fPIE", "-pie", "-o", exe, srcPath).CombinedOutput(); err != nil {
+		t.Skipf("g++ failed: %v: %s", err, out)
+	}
+	dbg := exe + ".debug"
+	out, err := exec.Command("objcopy", "--only-keep-debug", exe, dbg).CombinedOutput()
+	require.NoErrorf(t, err, "objcopy --only-keep-debug: %s", out)
+	stripped := exe + ".stripped"
+	require.NoError(t, debugCopyFile(stripped, exe))
+	out, err = exec.Command("strip", "--strip-all", stripped).CombinedOutput()
+	require.NoErrorf(t, err, "strip: %s", out)
+	// Force the DWARF path by removing the symbol table from the debug file.
+	out, err = exec.Command("objcopy", "--remove-section=.symtab", "--remove-section=.strtab", dbg, dbg).CombinedOutput()
+	require.NoErrorf(t, err, "objcopy --remove-section: %s", out)
+
+	got := nameOffsets(t, trace.SeparateDebugResolver(stripped, dbg, testLogger, "", "", nil, nil, false))
+
+	// Member/namespaced definitions (name via DW_AT_specification) and overloads
+	// (distinct linkage names) must all resolve.
+	for _, want := range []string{"_ZN6Widget6methodEi", "_ZN2ns6helperEi", "_Z3fooi", "_Z3food"} {
+		_, ok := got[want]
+		require.Truef(t, ok, "DWARF fallback missed %q; resolved: %v", want, keysOf(got))
+	}
+}
+
+func keysOf(m map[string]uint64) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+// TestSeparateDebugResolver_SectionlessExe verifies the resolver still works on
+// an executable whose section table has been removed (eu-strip --strip-sections):
+// build-id is read from PT_NOTE and offsets from PT_LOAD, so it matches the
+// unstripped resolution. This is the case where no other resolver can work.
+func TestSeparateDebugResolver_SectionlessExe(t *testing.T) {
+	if _, err := exec.LookPath("eu-strip"); err != nil {
+		t.Skip("eu-strip not available")
+	}
+	dir := t.TempDir()
+	exe, dbg, _ := buildDebugFixture(t, dir, "sl", debugFixtureSrc)
+
+	sectionless := exe + ".nosections"
+	require.NoError(t, debugCopyFile(sectionless, exe))
+	out, err := exec.Command("eu-strip", "--strip-sections", sectionless).CombinedOutput()
+	require.NoErrorf(t, err, "eu-strip --strip-sections: %s", out)
+
+	want := nameOffsets(t, trace.SymbolTableResolver(exe, testLogger, `^(alpha|beta|main)$`, "", nil, nil))
+	got := nameOffsets(t, trace.SeparateDebugResolver(sectionless, dbg, testLogger, `^(alpha|beta|main)$`, "", nil, nil, false))
+	require.Equal(t, want, got)
+}

--- a/pkg/trace/tracee-errors.go
+++ b/pkg/trace/tracee-errors.go
@@ -5,9 +5,11 @@ import (
 )
 
 var (
-	ErrNoFunctionSymbols = errors.New("no functions found")
-	ErrNoSymbolTable     = errors.New("no symbol table available")
-	ErrNoOffsets         = errors.New("no function offsets found")
-	ErrExePathEmpty      = errors.New("exe path is empty")
-	ErrElfFileNil        = errors.New("elf file is nil")
+	ErrNoFunctionSymbols    = errors.New("no functions found")
+	ErrNoSymbolTable        = errors.New("no symbol table available")
+	ErrNoOffsets            = errors.New("no function offsets found")
+	ErrExePathEmpty         = errors.New("exe path is empty")
+	ErrElfFileNil           = errors.New("elf file is nil")
+	ErrNoBuildID            = errors.New("executable or debug file has no GNU build-id")
+	ErrDebugBuildIDMismatch = errors.New("debug file build-id does not match executable")
 )


### PR DESCRIPTION
> **Stacked on #101.** The first two commits are that PR (uprobe identification fixes); this PR's own change is the last commit (`SeparateDebugResolver`). Best reviewed/merged after #101, or rebased once it lands. The duplicate-name/offset-keyed-cookie fix in #101 is a prerequisite: a debug file exposes the full `.symtab`/DWARF symbol set, where duplicate names are common.

## What

Adds `--debug-path` to `xcover run`. For a **stripped** binary, function names/addresses are read from a companion debug file (`objcopy --only-keep-debug`, a distro `-dbg` package, or a debuginfod artifact), while uprobe offsets are computed against the stripped executable at `--path`.

Today a stripped non-Go binary falls back to resurgo and reports only synthetic `func_0x<addr>` names. (Stripped **Go** already works via `.gopclntab` and is unaffected.)

## How / design (each point validated empirically)

- **Symbols from the debug file's `.symtab`** (retained by `--only-keep-debug` and `eu-strip -f`); **DWARF subprograms** as a best-effort fallback (prefers `DW_AT_linkage_name` so C++ overloads stay distinct; skips declarations/inlined instances; does not follow `DW_AT_specification`; split-DWARF `.dwo` is out of scope).
- **Offsets from the executable's `PT_LOAD` program headers, never the debug file.** Function VAs are identical in both (same link); program headers survive even `eu-strip --strip-sections`, where `.symtab`/`.dynsym`/`.eh_frame` are gone and no other resolver can work.
- **build-id verified from `PT_NOTE`** (not the `.note.gnu.build-id` section), so it works on section-stripped executables. Missing/mismatched build-id fails closed; `--no-build-id-check` bypasses.
- **Undefined/zero-address symbols filtered** (imported `printf`, etc.) — on a PIE, VA 0 maps to file offset 0 (the ELF header) and would otherwise attach a bogus probe.
- **Fails loud:** on error the resolver returns a non-`ErrNoSymbolTable` error, so `Init` reports it rather than silently falling back to synthetic recovery on the stripped binary.

## Tests (`//go:build integration`)

`.symtab` equivalence vs the unstripped binary, build-id mismatch, missing build-id (+ bypass), undefined-symbol filtering, DWARF fallback, and a section-stripped executable. All pass locally (`gofmt`/`go vet` clean).

## Runtime validation (privileged container, real kernel, `uprobe_multi`)

Target with deterministic partial coverage — `alpha`/`gamma_fn`/`main` run, `beta`/`delta` never:

```
stripped (no .symtab) + --debug-path : funcs_traced=[alpha,beta,gamma_fn,delta,main] (real names)
                                       funcs_ack=[alpha,gamma_fn,main]  cov=60%   ✓
sectionless (0 sections) + --debug-path: funcs_traced=[...5 real names...]
                                       funcs_ack=[alpha,gamma_fn,main]  cov=60%   ✓  (only --debug-path works here)
```

Resolver logged `resolved functions from debug file .symtab symbols=5` in both.

## Open question for the maintainer

build-id verification defaults to **fail-closed** (with `--no-build-id-check`). Some toolchains build without `--build-id`; if you'd prefer warn-and-proceed by default, easy to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)