### PR TITLE
chore(pkg/trace/tracee): cleanup offset and cookie api

### DIFF
--- a/pkg/trace/resolver_test.go
+++ b/pkg/trace/resolver_test.go
@@ -38,7 +38,7 @@ func TestWithTraceeResolver_CustomResolver(t *testing.T) {
 	assert.Contains(t, names, "custom.Alpha")
 	assert.Contains(t, names, "custom.Beta")
 
-	offsets := tracee.GetFuncOffsets()
+	offsets, _ := tracee.GetFuncProbes()
 	assert.Contains(t, offsets, uint64(0x1000))
 	assert.Contains(t, offsets, uint64(0x2000))
 }

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -94,13 +94,8 @@ func (t *UserTracee) ShouldIncludeSymbol(sym elf.Symbol) bool {
 
 // GetFuncProbes returns the uprobe attach offsets and their corresponding
 // cookies, collected in a single pass over the function map so that offsets[i]
-// and cookies[i] always describe the same function.
-//
-// Callers attaching a uprobe_multi link (which consumes the offsets and cookies
-// as parallel arrays) must use this method. Pairing the results of
-// GetFuncOffsets and GetFuncCookies is unsafe: each ranges the map
-// independently and Go randomizes map iteration order, so the two slices may
-// describe the functions in different orders.
+// and cookies[i] always describe the same function. Callers attaching a
+// uprobe_multi link consume the two slices as parallel arrays.
 func (t *UserTracee) GetFuncProbes() (offsets, cookies []uint64) {
 	offsets = make([]uint64, 0, len(t.funcs))
 	cookies = make([]uint64, 0, len(t.funcs))
@@ -109,28 +104,6 @@ func (t *UserTracee) GetFuncProbes() (offsets, cookies []uint64) {
 		cookies = append(cookies, uint64(c))
 	}
 	return offsets, cookies
-}
-
-// GetFuncOffsets returns the attach offsets of all collected functions, in
-// unspecified order. To attach probes, use GetFuncProbes instead, which keeps
-// offsets and cookies aligned.
-func (t *UserTracee) GetFuncOffsets() []uint64 {
-	offsets := make([]uint64, 0, len(t.funcs))
-	for c := range t.funcs {
-		offsets = append(offsets, t.funcs[c].offset)
-	}
-	return offsets
-}
-
-// GetFuncCookies returns the cookies of all collected functions, in unspecified
-// order. To attach probes, use GetFuncProbes instead, which keeps offsets and
-// cookies aligned.
-func (t *UserTracee) GetFuncCookies() []uint64 {
-	cookies := make([]uint64, 0, len(t.funcs))
-	for c := range t.funcs {
-		cookies = append(cookies, uint64(c))
-	}
-	return cookies
 }
 
 func (t *UserTracee) GetFuncNames() []string {

--- a/pkg/trace/tracee_integration_test.go
+++ b/pkg/trace/tracee_integration_test.go
@@ -375,8 +375,9 @@ func TestUserTracee_Init(t *testing.T) {
 	err := tracee.Init(t.Context())
 	require.NoError(t, err)
 	require.NotEmpty(t, tracee.GetFuncNames())
-	require.NotEmpty(t, tracee.GetFuncOffsets())
-	require.NotEmpty(t, tracee.GetFuncCookies())
+	offsets, cookies := tracee.GetFuncProbes()
+	require.NotEmpty(t, offsets)
+	require.NotEmpty(t, cookies)
 
 	tracee = NewUserTracee(
 		WithTraceeExePath("nonexistent-binary-file"),

--- a/pkg/trace/tracee_probe_test.go
+++ b/pkg/trace/tracee_probe_test.go
@@ -41,8 +41,9 @@ func TestUserTracee_GetterLengths(t *testing.T) {
 	tracee := newProbeTestTracee(t)
 	n := len(probeTestEntries)
 
-	require.Len(t, tracee.GetFuncOffsets(), n, "offsets slice has phantom entries")
-	require.Len(t, tracee.GetFuncCookies(), n, "cookies slice has phantom entries")
+	offsets, cookies := tracee.GetFuncProbes()
+	require.Len(t, offsets, n, "offsets slice has phantom entries")
+	require.Len(t, cookies, n, "cookies slice has phantom entries")
 	require.Len(t, tracee.GetFuncNames(), n, "names slice has phantom entries")
 }
 


### PR DESCRIPTION
Now that cookie and offsets are composed once the old API:
- `tracee.GetFuncOffsets`
- `tracee.GetFuncCookies` are supersed.

Update the integration tests to use the new API and remove the old ones.