### PR TITLE
chore(release): cross-compile libbpf for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '*.*.*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/release.yml'
+      - '.goreleaser.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -28,6 +35,16 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^URIs: /Architectures: amd64\nURIs: /' /etc/apt/sources.list.d/ubuntu.sources
+          cat <<'EOF' | sudo tee /etc/apt/sources.list.d/ubuntu-ports.sources
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports
+          Suites: noble noble-updates noble-backports noble-security
+          Components: main restricted universe multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
           sudo apt-get update
           sudo apt-get install -y \
             clang \
@@ -39,7 +56,9 @@ jobs:
             make \
             pkg-config \
             libelf-dev \
-            zlib1g-dev
+            libelf-dev:arm64 \
+            zlib1g-dev \
+            zlib1g-dev:arm64
 
       - name: Install bpftool and libbpf
         run: |
@@ -82,7 +101,19 @@ jobs:
           git config diff.ignoreSubmodules dirty
           git submodule foreach --recursive 'git config diff.ignoreSubmodules dirty'
 
+      - name: Run GoReleaser snapshot
+        if: github.event_name != 'push'
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PWD: ${{ github.workspace }}
+
       - name: Run GoReleaser
+        if: github.event_name == 'push'
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,8 +7,12 @@ before:
     # Initialize submodules
     - git submodule init
     - git submodule update --recursive
-    # Build libbpfgo statically
+    # Build libbpf statically for amd64 (host) and install UAPI headers
     - make -C libbpfgo libbpfgo-static
+    # Cross-compile libbpf statically for arm64 into a separate output dir
+    - make -C libbpfgo libbpf-static CC=aarch64-linux-gnu-gcc OUTPUT=./output-arm64
+    # UAPI headers are arch-independent; reuse from the amd64 build
+    - cp -r libbpfgo/output/linux libbpfgo/output-arm64/linux
     # Generate vmlinux.h if not present
     - bash -c 'if [ ! -f bpf/vmlinux.h ]; then bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h; fi'
 
@@ -46,8 +50,8 @@ builds:
         goarch: arm64
         env:
           - CC=aarch64-linux-gnu-gcc
-          - CGO_CFLAGS=-I {{ .Env.PWD }}/libbpfgo/output
-          - CGO_LDFLAGS=-lelf -lz {{ .Env.PWD }}/libbpfgo/output/libbpf/libbpf.a
+          - CGO_CFLAGS=-I {{ .Env.PWD }}/libbpfgo/output-arm64
+          - CGO_LDFLAGS=-lelf -lz {{ .Env.PWD }}/libbpfgo/output-arm64/libbpf/libbpf.a
 
 archives:
   - id: xcover


### PR DESCRIPTION
The before.hooks step built libbpfgo-static once on the x86_64 host, producing a single libbpf.a for  amd64. The arm64 build override correctly used aarch64-linux-gnu-gcc for the Go CGO step, but pointed at the same x86_64 libbpf.a, causing the linker to fail with 'file in wrong format'.

Fix by cross-compiling libbpf for arm64 into a separate output-arm64/ directory using aarch64-linux-gnu-gcc, then pointing the arm64 override at that directory. UAPI headers are arch-independent and are copied from the amd64 build.