### PR TITLE
feat(trace): fall back to binary scope when project scope is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ xcover run --path EXE_PATH --scope project
 
 Project scope uses Go build metadata to identify the module path, then keeps root `main.*` functions and symbols prefixed by that module path. This excludes functions from the Go standard library and third-party dependencies before `--include` and `--exclude` filters are applied.
 
-Build Go targets as packages or modules, for example `go build -o app .` or `go build -o app ./cmd/app`. Project scope is not available for single-file Go builds such as `go build main.go`, because Go records those binaries as `command-line-arguments` instead of a module-backed package.
+Build Go targets as packages or modules, for example `go build -o app .` or `go build -o app ./cmd/app`. Single-file builds such as `go build main.go` do not carry module metadata, so xcover logs a warning and falls back to binary scope for those binaries.
 
 ## Symbolization
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -88,7 +88,7 @@ xcover run --path EXE_PATH --scope project
 
 Project scope uses Go build metadata to identify the module path, then keeps root `main.*` functions and symbols prefixed by that module path. This excludes functions from the Go standard library and third-party dependencies before `--include` and `--exclude` filters are applied.
 
-Build Go targets as packages or modules, for example `go build -o app .` or `go build -o app ./cmd/app`. Project scope is not available for single-file Go builds such as `go build main.go`, because Go records those binaries as `command-line-arguments` instead of a module-backed package.
+Build Go targets as packages or modules, for example `go build -o app .` or `go build -o app ./cmd/app`. Single-file builds such as `go build main.go` do not carry module metadata, so xcover logs a warning and falls back to binary scope for those binaries.
 
 ## Symbolization
 

--- a/pkg/trace/resolver_go.go
+++ b/pkg/trace/resolver_go.go
@@ -29,13 +29,7 @@ func GoProjectResolver(path string, logger log.Logger, include, exclude string, 
 
 		modPath, err := goModulePath(path)
 		if err != nil {
-			var pathErr *os.PathError
-			if errors.As(err, &pathErr) {
-				// File missing or unreadable - not a scope issue, propagate as-is.
-				return nil, errors.Wrap(err, "failed to detect Go module path")
-			}
-			// Binary exists but lacks usable Go build info.
-			return nil, errors.Wrapf(ErrProjectScopeUnsupported, "failed to detect Go module path: %s", err)
+			return nil, errors.Wrap(err, "failed to detect Go module path")
 		}
 
 		logger.Info().
@@ -64,16 +58,29 @@ func GoProjectResolver(path string, logger log.Logger, include, exclude string, 
 }
 
 // goModulePath extracts the Go module path from the binary's embedded build info.
+//
+// Returns ErrProjectScopeUnsupported (via errors.Is) for exactly three cases:
+//   - binary has no .go.buildinfo section (non-Go binary)
+//   - binary was built as command-line-arguments
+//   - binary has an empty main module path
+//
+// File-system errors (*os.PathError) are returned as-is so callers can
+// distinguish "file unreadable" from "project scope not supported".
 func goModulePath(path string) (string, error) {
 	info, err := buildinfo.ReadFile(path)
 	if err != nil {
-		return "", err
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			return "", err
+		}
+		// Binary exists but has no .go.buildinfo section (non-Go binary).
+		return "", errors.Wrapf(ErrProjectScopeUnsupported, "no Go build info: %s", err)
 	}
 	if info.Path == "command-line-arguments" {
-		return "", errors.New("binary was built as command-line-arguments; build the package or module instead")
+		return "", errors.Wrap(ErrProjectScopeUnsupported, "binary was built as command-line-arguments; build the package or module instead")
 	}
 	if info.Main.Path == "" {
-		return "", errors.New("binary has no main module path")
+		return "", errors.Wrap(ErrProjectScopeUnsupported, "binary has no main module path")
 	}
 	return info.Main.Path, nil
 }

--- a/pkg/trace/resolver_go.go
+++ b/pkg/trace/resolver_go.go
@@ -59,8 +59,9 @@ func GoProjectResolver(path string, logger log.Logger, include, exclude string, 
 
 // goModulePath extracts the Go module path from the binary's embedded build info.
 //
-// Returns ErrProjectScopeUnsupported (via errors.Is) for exactly three cases:
-//   - binary has no .go.buildinfo section (non-Go binary)
+// Returns ErrProjectScopeUnsupported (via errors.Is) in three situations:
+//   - buildinfo.ReadFile failed for a non-filesystem reason (no build info,
+//     corrupt ELF, non-Go binary)
 //   - binary was built as command-line-arguments
 //   - binary has an empty main module path
 //

--- a/pkg/trace/resolver_go.go
+++ b/pkg/trace/resolver_go.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"debug/buildinfo"
 	"debug/elf"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +29,13 @@ func GoProjectResolver(path string, logger log.Logger, include, exclude string, 
 
 		modPath, err := goModulePath(path)
 		if err != nil {
-			return nil, errors.Wrapf(ErrProjectScopeUnsupported, "failed to detect Go module path: %v", err)
+			var pathErr *os.PathError
+			if errors.As(err, &pathErr) {
+				// File missing or unreadable - not a scope issue, propagate as-is.
+				return nil, errors.Wrap(err, "failed to detect Go module path")
+			}
+			// Binary exists but lacks usable Go build info.
+			return nil, errors.Wrapf(ErrProjectScopeUnsupported, "failed to detect Go module path: %s", err)
 		}
 
 		logger.Info().

--- a/pkg/trace/resolver_go.go
+++ b/pkg/trace/resolver_go.go
@@ -17,8 +17,9 @@ import (
 // It reads the embedded Go build info to discover the module path, then
 // delegates to SymbolTableResolver and filters the results.
 //
-// Returns an error if the binary is not a Go binary or the module path
-// cannot be determined.
+// Returns ErrProjectScopeUnsupported (via errors.Is) if the binary does not
+// carry the metadata needed for project-scoped resolution (missing build info,
+// built as command-line-arguments, etc.).
 func GoProjectResolver(path string, logger log.Logger, include, exclude string, bindInclude, bindExclude []elf.SymBind) FunctionResolver {
 	return func(ctx context.Context) ([]FunctionEntry, error) {
 		if err := ctx.Err(); err != nil {
@@ -27,7 +28,7 @@ func GoProjectResolver(path string, logger log.Logger, include, exclude string, 
 
 		modPath, err := goModulePath(path)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to detect Go module path (is this a Go binary?)")
+			return nil, errors.Wrapf(ErrProjectScopeUnsupported, "failed to detect Go module path: %v", err)
 		}
 
 		logger.Info().
@@ -68,6 +69,25 @@ func goModulePath(path string) (string, error) {
 		return "", errors.New("binary has no main module path")
 	}
 	return info.Main.Path, nil
+}
+
+// withProjectFallback wraps primary so that if it returns ErrProjectScopeUnsupported
+// the error is logged as a warning and fallback is used instead. Any other error
+// from primary is returned as-is.
+func withProjectFallback(primary, fallback FunctionResolver, logger log.Logger) FunctionResolver {
+	return func(ctx context.Context) ([]FunctionEntry, error) {
+		entries, err := primary(ctx)
+		if err == nil {
+			return entries, nil
+		}
+		if !errors.Is(err, ErrProjectScopeUnsupported) {
+			return nil, err
+		}
+		logger.Warn().
+			Err(err).
+			Msg("project scope unavailable, falling back to binary scope")
+		return fallback(ctx)
+	}
 }
 
 // filterByModulePath keeps FunctionEntry values belonging to the main module.

--- a/pkg/trace/resolver_go_integration_test.go
+++ b/pkg/trace/resolver_go_integration_test.go
@@ -212,6 +212,39 @@ func TestGoProjectResolver_StrippedGoBinary(t *testing.T) {
 	}
 }
 
+// TestScopeIntegration_ProjectFallback_NonGoBinary verifies that UserTracee.Init
+// with ScopeProject falls back to binary scope on a non-Go binary, rather than
+// failing. This pins the full defaultResolver -> withProjectFallback -> Init path:
+// rewording the ErrProjectScopeUnsupported wrap in resolver_go.go would break
+// the fallback while leaving the unit tests green.
+func TestScopeIntegration_ProjectFallback_NonGoBinary(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "hello.c")
+	require.NoError(t, os.WriteFile(src, []byte(`
+#include <stdio.h>
+void greet(void) { printf("hello\n"); }
+int main(void) { greet(); return 0; }
+`), 0o644))
+
+	bin := filepath.Join(dir, "hello")
+	out, err := exec.Command("gcc", "-o", bin, src).CombinedOutput()
+	if err != nil {
+		t.Skipf("gcc unavailable: %v: %s", err, out)
+	}
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.DebugLevel)
+	tracee := trace.NewUserTracee(
+		trace.WithTraceeExePath(bin),
+		trace.WithTraceeScope(trace.ScopeProject),
+		trace.WithTraceeLogger(logger),
+	)
+
+	require.NoError(t, tracee.Init(t.Context()),
+		"ScopeProject on a C binary should fall back to binary scope, not fail")
+	require.NotEmpty(t, tracee.GetFuncNames(),
+		"fallback should resolve binary-scope functions")
+}
+
 // TestScopeIntegration_TraceeInit verifies the full tracee init path with
 // scope=project, which is how users actually use it via --scope=project.
 func TestScopeIntegration_TraceeInit(t *testing.T) {

--- a/pkg/trace/resolver_go_test.go
+++ b/pkg/trace/resolver_go_test.go
@@ -1,7 +1,11 @@
 package trace
 
 import (
+	"context"
 	"testing"
+
+	"github.com/pkg/errors"
+	log "github.com/rs/zerolog"
 )
 
 func TestFilterByModulePath(t *testing.T) {
@@ -47,5 +51,51 @@ func TestFilterByModulePath_NoMatch(t *testing.T) {
 	got := filterByModulePath(entries, "github.com/user/repo")
 	if len(got) != 0 {
 		t.Errorf("expected empty result, got %d entries", len(got))
+	}
+}
+
+func staticResolver(entries []FunctionEntry, err error) FunctionResolver {
+	return func(_ context.Context) ([]FunctionEntry, error) {
+		return entries, err
+	}
+}
+
+func TestWithProjectFallback_UsesPrimaryOnSuccess(t *testing.T) {
+	primary := staticResolver([]FunctionEntry{{Name: "main.Foo", Offset: 0x1000}}, nil)
+	fallback := staticResolver([]FunctionEntry{{Name: "other.Bar", Offset: 0x2000}}, nil)
+
+	resolver := withProjectFallback(primary, fallback, log.Nop())
+	got, err := resolver(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "main.Foo" {
+		t.Errorf("expected primary result, got %v", got)
+	}
+}
+
+func TestWithProjectFallback_FallsBackOnUnsupported(t *testing.T) {
+	primary := staticResolver(nil, errors.Wrap(ErrProjectScopeUnsupported, "no buildinfo"))
+	fallback := staticResolver([]FunctionEntry{{Name: "other.Bar", Offset: 0x2000}}, nil)
+
+	resolver := withProjectFallback(primary, fallback, log.Nop())
+	got, err := resolver(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "other.Bar" {
+		t.Errorf("expected fallback result, got %v", got)
+	}
+}
+
+func TestWithProjectFallback_PropagatesOtherErrors(t *testing.T) {
+	sentinel := errors.New("some other failure")
+	primary := staticResolver(nil, sentinel)
+	fallback := staticResolver([]FunctionEntry{{Name: "other.Bar", Offset: 0x2000}}, nil)
+
+	resolver := withProjectFallback(primary, fallback, log.Nop())
+	_, err := resolver(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
 	}
 }

--- a/pkg/trace/resolver_go_test.go
+++ b/pkg/trace/resolver_go_test.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,24 @@ func TestFilterByModulePath_NoMatch(t *testing.T) {
 	got := filterByModulePath(entries, "github.com/user/repo")
 	if len(got) != 0 {
 		t.Errorf("expected empty result, got %d entries", len(got))
+	}
+}
+
+// TestGoProjectResolver_NonexistentBinary verifies that a missing file yields
+// an error that is NOT ErrProjectScopeUnsupported and still carries *os.PathError
+// in its chain. Reverting the *os.PathError guard in goModulePath would break this.
+func TestGoProjectResolver_NonexistentBinary(t *testing.T) {
+	resolver := GoProjectResolver("/nonexistent-binary-path", log.Nop(), "", "", nil, nil)
+	_, err := resolver(context.Background())
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary, got nil")
+	}
+	if errors.Is(err, ErrProjectScopeUnsupported) {
+		t.Errorf("nonexistent path should not be ErrProjectScopeUnsupported, got: %v", err)
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Errorf("expected *os.PathError in error chain, got: %v", err)
 	}
 }
 

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -83,7 +83,7 @@ func (t *UserTracee) Init(ctx context.Context) error {
 // configured scope. If scope is empty, it defaults to ScopeBinary.
 //
 // When ScopeProject is requested, the resolver falls back to binary scope if
-// the binary does not carry usable Go build info (no .go_buildinfo section,
+// the binary does not carry usable Go build info (no .go.buildinfo section,
 // built as command-line-arguments, or empty main module path). A warning is
 // logged in that case. Other failures, including a binary with valid build info
 // but no symbols matching the module path, are returned as errors.

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -82,10 +82,11 @@ func (t *UserTracee) Init(ctx context.Context) error {
 // defaultResolver returns the appropriate FunctionResolver for the tracee's
 // configured scope. If scope is empty, it defaults to ScopeBinary.
 //
-// When ScopeProject is requested, the resolver automatically falls back to
-// binary scope if the binary does not carry the metadata required for project
-// scoping (e.g. missing Go build info, built as command-line-arguments). A
-// warning is logged in that case.
+// When ScopeProject is requested, the resolver falls back to binary scope if
+// the binary does not carry usable Go build info (no .go_buildinfo section,
+// built as command-line-arguments, or empty main module path). A warning is
+// logged in that case. Other failures, including a binary with valid build info
+// but no symbols matching the module path, are returned as errors.
 func (t *UserTracee) defaultResolver() FunctionResolver {
 	binary := SymbolTableResolver(t.exePath, t.logger, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
 	switch t.scope {

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -81,12 +81,19 @@ func (t *UserTracee) Init(ctx context.Context) error {
 
 // defaultResolver returns the appropriate FunctionResolver for the tracee's
 // configured scope. If scope is empty, it defaults to ScopeBinary.
+//
+// When ScopeProject is requested, the resolver automatically falls back to
+// binary scope if the binary does not carry the metadata required for project
+// scoping (e.g. missing Go build info, built as command-line-arguments). A
+// warning is logged in that case.
 func (t *UserTracee) defaultResolver() FunctionResolver {
+	binary := SymbolTableResolver(t.exePath, t.logger, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
 	switch t.scope {
 	case ScopeProject:
-		return GoProjectResolver(t.exePath, t.logger, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
+		project := GoProjectResolver(t.exePath, t.logger, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
+		return withProjectFallback(project, binary, t.logger)
 	default:
-		return SymbolTableResolver(t.exePath, t.logger, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
+		return binary
 	}
 }
 

--- a/pkg/trace/tracee_errors.go
+++ b/pkg/trace/tracee_errors.go
@@ -12,4 +12,10 @@ var (
 	ErrElfFileNil           = errors.New("elf file is nil")
 	ErrNoBuildID            = errors.New("executable or debug file has no GNU build-id")
 	ErrDebugBuildIDMismatch = errors.New("debug file build-id does not match executable")
+
+	// ErrProjectScopeUnsupported is returned by GoProjectResolver when the
+	// binary does not carry the metadata required for project-scoped function
+	// resolution (e.g. missing or incomplete Go build info). Callers may treat
+	// this as a signal to fall back to binary-scope resolution.
+	ErrProjectScopeUnsupported = errors.New("project scope not supported for this binary")
 )


### PR DESCRIPTION
## Why

When `--scope=project` is used against a binary that does not carry Go build info (e.g. built as `command-line-arguments`, a non-Go binary, or one without a `.go.buildinfo` section), xcover would hard-fail with:

```
failed to resolve functions: failed to detect Go module path (is this a Go binary?): binary was built as command-line-arguments
```

Project scoping is best-effort: if the binary does not support it, binary scope is the right fallback rather than an outright failure.

## What

Introduces a typed sentinel `ErrProjectScopeUnsupported` that `GoProjectResolver` returns whenever build info is missing or unusable. `defaultResolver` wraps the project resolver with `withProjectFallback`, which catches that sentinel, logs a warning, and delegates to `SymbolTableResolver`.

Any other error from the primary resolver is still propagated as-is, so genuine failures (e.g. empty symbol table) are not swallowed.

## How

- `ErrProjectScopeUnsupported` sentinel in `tracee_errors.go` - inspectable via `errors.Is`
- `withProjectFallback(primary, fallback, logger)` - a pure resolver wrapper, easy to test in isolation and composable if other scope types need the same pattern later
- `defaultResolver` in `tracee.go` builds the fallback chain only for `ScopeProject`; explicit custom resolvers passed via `WithResolver` are unaffected
- Unit tests for all three paths: primary success, fallback on unsupported, propagation of unrelated errors