### PR TITLE
chore(demo): parameterize sleep duration

### DIFF
--- a/demo/basic/demo.sh
+++ b/demo/basic/demo.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
+SLEEP="${SLEEP:-2}"
 
 function cleanup() {
     ${XCOVER} stop 2>/dev/null || true
@@ -30,7 +31,7 @@ function main() {
 	echo
 	runCmd "# Let's test a demo Go application"
 	runCmd "bat ../src/go/demo-app.go"
-	sleep 2
+	sleep "${SLEEP}"
 	clear
 	runCmd "go build -o demo-app ../src/go/"
 	runCmd "ls demo-app"
@@ -58,7 +59,7 @@ function runCmd() {
 	cmd=$1
 	echo "$ ${cmd}"
 	eval "${cmd}"
-	sleep 2
+	sleep "${SLEEP}"
 }
 
 main $@

--- a/demo/debugfile/demo.sh
+++ b/demo/debugfile/demo.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEMO_APP="./demo-app"
 DEBUG_FILE="./demo-app.debug"
 XCOVER="${SCRIPT_DIR}/../../xcover"
+SLEEP="${SLEEP:-2}"
 
 function cleanup() {
     ${XCOVER} stop 2>/dev/null || true
@@ -33,7 +34,7 @@ function main() {
 	echo
 	runCmd "# Let's test a demo C application"
 	runCmd "bat ../src/c/demo-app.c"
-	sleep 2
+	sleep "${SLEEP}"
 	clear
 	runCmd "gcc -O0 -g -o demo-app ../src/c/demo-app.c"
 	runCmd "# Extract debug info into a separate file"
@@ -43,7 +44,7 @@ function main() {
 	runCmd "readelf --symbols demo-app | wc -l"
 	runCmd "# The debug file retains the symbols"
 	runCmd "readelf --symbols demo-app.debug | wc -l"
-	sleep 1
+	sleep "${SLEEP}"
 	clear
 	runCmd "# Start the profiler — point it at both the binary and the debug file"
 	runCmd "${XCOVER} run --detach --path demo-app --debug-path demo-app.debug --include '^(main|add|multiply|subtract|divide|greet)$'"
@@ -69,7 +70,7 @@ function runCmd() {
 	cmd=$1
 	echo "$ ${cmd}"
 	eval "${cmd}"
-	sleep 2
+	sleep "${SLEEP}"
 }
 
 main $@

--- a/demo/stripped/demo.sh
+++ b/demo/stripped/demo.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
+SLEEP="${SLEEP:-2}"
 
 function cleanup() {
     ${XCOVER} stop 2>/dev/null || true
@@ -31,7 +32,7 @@ function main() {
 	echo
 	runCmd "# Let's test a demo C application"
 	runCmd "bat ../src/c/demo-app.c"
-	sleep 2
+	sleep "${SLEEP}"
 	clear
 	runCmd "gcc -O0 -o demo-app ../src/c/demo-app.c"
 	runCmd "readelf --symbols demo-app | wc -l"
@@ -62,7 +63,7 @@ function runCmd() {
 	cmd=$1
 	echo "$ ${cmd}"
 	eval "${cmd}"
-	sleep 2
+	sleep "${SLEEP}"
 }
 
 main $@


### PR DESCRIPTION
Demo scripts have hardcoded `sleep 2` calls between steps, which makes iterating during testing slow. This makes the delay configurable via a `SLEEP` env var, defaulting to `2` so existing usage is unchanged.

To test without delays:

```
sudo SLEEP=0 ./demo.sh
```