### PR TITLE
feat(demo): open tmux log pane automatically

### DIFF
--- a/demo/basic/demo.sh
+++ b/demo/basic/demo.sh
@@ -9,7 +9,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP
@@ -25,6 +29,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Functional Test Coverage Profiler ==="
 	runCmd "# Profile coverage without instrumenting your binaries!"

--- a/demo/debugfile/demo.sh
+++ b/demo/debugfile/demo.sh
@@ -12,7 +12,11 @@ DEBUG_FILE="./demo-app.debug"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP $DEBUG_FILE
@@ -28,6 +32,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Coverage with a separate debug file ==="
 	runCmd "# Strip the binary for production. Keep the debug file for profiling."

--- a/demo/lib/log-pane.sh
+++ b/demo/lib/log-pane.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# log-pane.sh — tmux log pane helper for xcover demos.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/log-pane.sh"
+#
+#   setup_log_pane kernel      # tail /sys/kernel/debug/tracing/trace_pipe
+#   setup_log_pane userspace   # tail ~/.bpftime/runtime.log
+#
+#   Call teardown_log_pane in your cleanup() function.
+
+LOG_PANE=""
+
+function setup_log_pane() {
+    [ -z "${TMUX:-}" ] && return
+    local mode="${1:-kernel}"
+    local log_cmd
+    if [ "$mode" = "userspace" ]; then
+        log_cmd="tail -f ~/.bpftime/runtime.log"
+    else
+        log_cmd="cat /sys/kernel/debug/tracing/trace_pipe"
+    fi
+    LOG_PANE=$(tmux split-window -h -P -F "#{pane_id}" "$log_cmd")
+    tmux select-pane -L
+}
+
+function teardown_log_pane() {
+    [ -n "${LOG_PANE:-}" ] && tmux kill-pane -t "$LOG_PANE" 2>/dev/null || true
+    LOG_PANE=""
+}

--- a/demo/stripped/demo.sh
+++ b/demo/stripped/demo.sh
@@ -10,7 +10,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP
@@ -26,6 +30,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Coverage on stripped binaries ==="
 	runCmd "# No source instrumentation. No debug info. Just the binary."


### PR DESCRIPTION
When a demo script runs inside tmux, it now automatically splits a pane on the right and tails the relevant log source:

- **Kernel mode**: `/sys/kernel/debug/tracing/trace_pipe` — see BPF uprobe hits in real time
- **Userspace mode**: `~/.bpftime/runtime.log` — ready for future bpftime demos

The pane is killed cleanly when the demo exits. Outside tmux, nothing changes.

The logic lives in `demo/lib/log-pane.sh` so adding new demo scripts is a one-liner (`setup_log_pane kernel` or `setup_log_pane userspace`).