### PR TITLE
chore: bump xcover-build digests on userspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ $(OUTPUT):
 
 # container build
 
-BUILD_IMAGE          := ghcr.io/maxgio92/xcover-build@sha256:fd798eb6ab7304cb85bc06d5418bc479abf9294c370682b5518456d81a7451f3
-BUILD_IMAGE_USERSPACE := ghcr.io/maxgio92/xcover-build@sha256:10926b4ed4e416b03522c5340785f911c8f3449a6f4845911ddaacb4a262259f
+BUILD_IMAGE          := ghcr.io/maxgio92/xcover-build@sha256:5d29a51d855daba2151b32d4d0f36366e18d3ffa918763d08d98cb23c0fb031c
+BUILD_IMAGE_USERSPACE := ghcr.io/maxgio92/xcover-build@sha256:79163cff78b67e27d715c0ed6fe187eebb99904df43d444a20d358154ca2e559
 
 define build-in-container
 	$(git) submodule update --init --recursive


### PR DESCRIPTION
The `userspace` branch had drifted from the published build images — its pins were never advancing while `main` stayed current.

- `BUILD_IMAGE`: `fd798eb6` → **`5d29a51d`** (current live `:latest`)
- `BUILD_IMAGE_USERSPACE`: `10926b4e` → **`79163cff`** (current live `:userspace`)

Root cause of the drift is in `maxgio92/xcover-build` `.github/workflows/build.yml` (fixed in a separate PR): the userspace leg's `sed` used `^BUILD_IMAGE :=` (single space) which never matched this branch's column-aligned `BUILD_IMAGE          :=`, so `create-pull-request` saw no diff and skipped ("not ahead of base 'userspace'"). It also targeted `BUILD_IMAGE` instead of `BUILD_IMAGE_USERSPACE`.

This PR is the one-time catch-up; the workflow fix prevents recurrence.