### PR TITLE
chore(deps): bump libbpfgo to main incl. attach_uprobe_opts (#530)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/maxgio92/xcover
 go 1.26.1
 
 require (
-	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1
+	github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-02bd337ecb5d
 	github.com/maxgio92/resurgo v0.4.2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1 h1:QO9P9p9E1wh7lrlUJ613Wd4zIZeNv36x9e0Hm8Ek4B8=
-github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1/go.mod h1:jdsIjOUUTpTDiqE/MUg17yOt7oqTlmaNnDuTbspaaCU=
+github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-02bd337ecb5d h1:c2HsqQytTAgGkS3mEBABeJLrYEiQsmW9xUmA1ppB6/w=
+github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-02bd337ecb5d/go.mod h1:bRzdRnYH24hENJCufBHJvSbtFIhtWSAGg4OSWhvyLso=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -41,7 +41,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.76 h1:mrdLPj8ujM6eIKGtd1PkkuCIodpFFDM42Cfm0YODkIM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.76/go.mod h1:7V2BQeHnVAQwhCnCPJ977giCeGDiywVewWF+8vkpPlc=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 h1:3DyzQ30OHt3wiOZVL1se2g1PAPJIU7+tMUyvfMUj1dY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.76/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.78 h1:jgqg4gyu2BaYW9L6uzEtGLf8GNREwk/z4UFdwt5F3pE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.78/go.mod h1:VjuVda6m2qGkpCVfrFkpTGyvkdlZ2N5/yfo89tujlg8=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.78 h1:PC3yNs51cX5LZ7U57a7xielBcoXB3xnV+rXD8V0H0DQ=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.78/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=


### PR DESCRIPTION
Draft.

Bumps libbpfgo from the pre-merge #530 branch pin to a main-based pseudo-version that includes the merged aquasecurity/libbpfgo#530:

- before: `v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1` (PR branch commit, can be force-deleted)
- after: `v0.10.0-libbpf-1.5.1.0.20260630133552-02bd337ecb5d` (merge commit on main)

#530 adds `AttachUprobeWithOpts` / `AttachURetprobeWithOpts` with `bpf_cookie`, which is the API xcover already calls in `pkg/probe/probe.go`. No code change needed. This just moves the pin from a transient PR branch to main.

Verified: `AttachUprobeWithOpts` present at the new version (prog.go:640), `go mod verify` passes. Transitive `libcap` bump 1.2.76 -> 1.2.78 pulled in by `go mod tidy`.

Notes:
- No tagged release includes #530 yet (latest is `v0.10.0-libbpf-1.5.1`, 10 commits behind the merge). Re-pin to a clean tag once upstream cuts one. Draft until then, or merge now if you want off the PR-branch pin.
- Supersedes dependabot #126: bumping to the `v0.10.0-libbpf-1.5.1` tag would regress, that tag predates #530 and lacks `AttachUprobeWithOpts`. #126 should be closed.
- Submodule untouched: this is a Go-binding change; `bpf_program__attach_uprobe_opts` is long-standing libbpf C.