### PR TITLE
feat(merge): aggregate coverage reports across runs

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/maxgio92/xcover/internal/settings"
+	"github.com/maxgio92/xcover/pkg/cmd/merge"
 	"github.com/maxgio92/xcover/pkg/cmd/options"
 	"github.com/maxgio92/xcover/pkg/cmd/run"
 	"github.com/maxgio92/xcover/pkg/cmd/status"
@@ -53,6 +54,7 @@ At the end of your tests, the profiler can be stopped and a report being collect
 	cmd.AddCommand(wait.NewCommand(o))
 	cmd.AddCommand(status.NewCommand(o))
 	cmd.AddCommand(stop.NewCommand(o))
+	cmd.AddCommand(merge.NewCommand(o))
 
 	return cmd
 }

--- a/pkg/cmd/merge/merge.go
+++ b/pkg/cmd/merge/merge.go
@@ -1,0 +1,89 @@
+package merge
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/maxgio92/xcover/pkg/cmd/options"
+	"github.com/maxgio92/xcover/pkg/coverage"
+)
+
+const CmdName = "merge"
+
+type Options struct {
+	output string
+
+	*options.Options
+}
+
+func NewCommand(opts *options.Options) *cobra.Command {
+	o := &Options{Options: opts}
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s <report.json> [report.json...]", CmdName),
+		Short: "Merge multiple coverage reports into one",
+		Long: `
+merge combines coverage reports produced by separate runs (parallel shards,
+distributed E2E, retries) into a single aggregate report.
+
+Reports are merged by function name: a function counts as covered if it was
+acknowledged in any input. Coverage is recomputed over the union. The inputs
+must come from the same binary; a merge spanning different binaries is reported
+as a warning and the resulting exe_path is left empty.`,
+		Args:              cobra.MinimumNArgs(1),
+		DisableAutoGenTag: true,
+		SilenceUsage:      true,
+		RunE:              o.Run,
+	}
+
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Write the merged report to this file instead of stdout")
+
+	return cmd
+}
+
+func (o *Options) Run(_ *cobra.Command, args []string) error {
+	reports := make([]*coverage.CoverageReport, 0, len(args))
+	for _, path := range args {
+		f, err := os.Open(path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open report %q", path)
+		}
+
+		report, err := coverage.ReadReport(f)
+		f.Close()
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse report %q", path)
+		}
+
+		reports = append(reports, report)
+	}
+
+	if paths := coverage.ExePaths(reports...); len(paths) > 1 {
+		o.Logger.Warn().
+			Strs("exe_paths", paths).
+			Msg("merging reports from different binaries; coverage may be meaningless and exe_path is left empty")
+	}
+
+	merged, err := coverage.Merge(reports...)
+	if err != nil {
+		return errors.Wrap(err, "failed to merge reports")
+	}
+
+	out := os.Stdout
+	if o.output != "" {
+		f, err := os.Create(o.output)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create output file %q", o.output)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if err := merged.WriteReport(out); err != nil {
+		return errors.Wrap(err, "failed to write merged report")
+	}
+
+	return nil
+}

--- a/pkg/coverage/merge.go
+++ b/pkg/coverage/merge.go
@@ -1,0 +1,89 @@
+package coverage
+
+import (
+	"errors"
+	"sort"
+)
+
+// ErrNoReports is returned when Merge is called without any report.
+var ErrNoReports = errors.New("no reports to merge")
+
+// Merge combines multiple coverage reports into a single aggregate report.
+//
+// Reports are merged by function name: a function is traced in the result if it
+// was traced in any input, and acknowledged (covered) if it was acknowledged in
+// any input. Coverage is recomputed as the ratio of the merged acknowledged set
+// to the merged traced set, as a percentage.
+//
+// Function identity is the symbol name emitted by xcover, so the inputs must
+// come from the same binary (or binaries sharing a symbol namespace); merging
+// reports from unrelated binaries yields meaningless numbers. Merge preserves a
+// single ExePath only when every input agrees on it, so callers can detect a
+// cross-binary merge by an empty ExePath on the result.
+func Merge(reports ...*CoverageReport) (*CoverageReport, error) {
+	if len(reports) == 0 {
+		return nil, ErrNoReports
+	}
+
+	tracedSet := make(map[string]struct{})
+	ackSet := make(map[string]struct{})
+	exePaths := make(map[string]struct{})
+
+	for _, r := range reports {
+		if r == nil {
+			continue
+		}
+		for _, f := range r.FuncsTraced {
+			tracedSet[f] = struct{}{}
+		}
+		for _, f := range r.FuncsAck {
+			ackSet[f] = struct{}{}
+		}
+		if r.ExePath != "" {
+			exePaths[r.ExePath] = struct{}{}
+		}
+	}
+
+	traced := sortedKeys(tracedSet)
+	ack := sortedKeys(ackSet)
+
+	var cov float64
+	if len(traced) > 0 {
+		cov = float64(len(ack)) / float64(len(traced)) * 100
+	}
+
+	merged := NewCoverageReport(
+		WithReportFuncsTraced(traced),
+		WithReportFuncsAck(ack),
+		WithReportFuncsCov(cov),
+	)
+
+	if len(exePaths) == 1 {
+		merged.ExePath = sortedKeys(exePaths)[0]
+	}
+
+	return merged, nil
+}
+
+// ExePaths returns the distinct, sorted ExePath values across the reports,
+// letting callers warn when a merge spans more than one binary.
+func ExePaths(reports ...*CoverageReport) []string {
+	set := make(map[string]struct{})
+	for _, r := range reports {
+		if r != nil && r.ExePath != "" {
+			set[r.ExePath] = struct{}{}
+		}
+	}
+
+	return sortedKeys(set)
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}

--- a/pkg/coverage/merge_test.go
+++ b/pkg/coverage/merge_test.go
@@ -1,0 +1,82 @@
+package coverage_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/maxgio92/xcover/pkg/coverage"
+)
+
+func TestMergeUnionsTracedAndAck(t *testing.T) {
+	r1 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a", "main.b", "main.c"}),
+		coverage.WithReportFuncsAck([]string{"main.a"}),
+		coverage.WithReportExePath("mybin"),
+	)
+	r2 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a", "main.b", "main.c"}),
+		coverage.WithReportFuncsAck([]string{"main.b"}),
+		coverage.WithReportExePath("mybin"),
+	)
+
+	merged, err := coverage.Merge(r1, r2)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"main.a", "main.b", "main.c"}, merged.FuncsTraced)
+	require.Equal(t, []string{"main.a", "main.b"}, merged.FuncsAck)
+	// 2 of 3 functions covered across the shards.
+	require.InDelta(t, 66.6667, merged.CovByFunc, 0.001)
+	require.Equal(t, "mybin", merged.ExePath)
+}
+
+func TestMergeDeduplicatesAndSorts(t *testing.T) {
+	r1 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.z", "main.a"}),
+		coverage.WithReportFuncsAck([]string{"main.z", "main.z"}),
+	)
+	r2 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a", "main.m"}),
+		coverage.WithReportFuncsAck([]string{"main.a"}),
+	)
+
+	merged, err := coverage.Merge(r1, r2)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"main.a", "main.m", "main.z"}, merged.FuncsTraced)
+	require.Equal(t, []string{"main.a", "main.z"}, merged.FuncsAck)
+}
+
+func TestMergeDivergentExePathsLeftEmpty(t *testing.T) {
+	r1 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a"}),
+		coverage.WithReportExePath("binA"),
+	)
+	r2 := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a"}),
+		coverage.WithReportExePath("binB"),
+	)
+
+	merged, err := coverage.Merge(r1, r2)
+	require.NoError(t, err)
+
+	require.Empty(t, merged.ExePath)
+	require.Equal(t, []string{"binA", "binB"}, coverage.ExePaths(r1, r2))
+}
+
+func TestMergeNoReportsErrors(t *testing.T) {
+	_, err := coverage.Merge()
+	require.ErrorIs(t, err, coverage.ErrNoReports)
+}
+
+func TestMergeSingleReportRecomputesCoverage(t *testing.T) {
+	r := coverage.NewCoverageReport(
+		coverage.WithReportFuncsTraced([]string{"main.a", "main.b"}),
+		coverage.WithReportFuncsAck([]string{"main.a"}),
+		coverage.WithReportFuncsCov(99), // stale value must be recomputed
+	)
+
+	merged, err := coverage.Merge(r)
+	require.NoError(t, err)
+	require.Equal(t, 50.0, merged.CovByFunc)
+}

--- a/pkg/coverage/report.go
+++ b/pkg/coverage/report.go
@@ -51,3 +51,13 @@ func (r *CoverageReport) WriteReport(w io.Writer) error {
 	encoder := json.NewEncoder(w)
 	return encoder.Encode(r)
 }
+
+// ReadReport decodes a CoverageReport from r, as written by WriteReport.
+func ReadReport(r io.Reader) (*CoverageReport, error) {
+	report := new(CoverageReport)
+	if err := json.NewDecoder(r).Decode(report); err != nil {
+		return nil, err
+	}
+
+	return report, nil
+}


### PR DESCRIPTION
## What

Adds `xcover merge <report.json>...` to combine coverage reports from separate runs (parallel shards, distributed E2E, retries) into one aggregate report.

This is feature **#4** from the roadmap discussion. It's the substrate under per-test attribution (#3) and is a prerequisite for patch coverage (#2) working in real sharded CI.

## How

- Merge by **function name**: a function is `traced` if traced in any input, `ack` (covered) if acknowledged in any input; `cov_by_func` is recomputed over the union.
- `exe_path` is preserved only when every input agrees; a cross-binary merge leaves it empty and logs a warning (function names from unrelated binaries aren't comparable).
- Deterministic, sorted output.
- Adds `coverage.ReadReport` as the counterpart to the existing `WriteReport`.

## Notes / follow-ups

- Function identity is the bare symbol name today. When a report carries a build-id (not yet in the format), keying on build-id + name would make cross-host merges safe rather than best-effort. Left as a follow-up so this stays a clean, format-compatible change.
- Format is intentionally left room to grow a per-run tag field for #3 (per-test attribution); merge already unions cleanly and that field would be preserved rather than flattened.

## Test

- `go test ./pkg/coverage/...` — union/dedup/sort, divergent exe_path, empty-input error, coverage recompute.
- `go build`/`go vet ./pkg/cmd/merge/` clean. Full binary build (cgo/libbpf) left to CI.

Draft pending your review of the merge semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)