### PR TITLE
build(deps): bump libbpfgo for uprobe cookie attach opts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/maxgio92/xcover
 go 1.26.1
 
 require (
-	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1
+	github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-7d3a1fe9451f
 	github.com/maxgio92/resurgo v0.4.2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
@@ -24,6 +25,5 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.24.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1 h1:QO9P9p9E1wh7lrlUJ613Wd4zIZeNv36x9e0Hm8Ek4B8=
-github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20251010210924-f23a41262be1/go.mod h1:jdsIjOUUTpTDiqE/MUg17yOt7oqTlmaNnDuTbspaaCU=
+github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-7d3a1fe9451f h1:B05uap5M/8eedCLZJUifwVQo7RcC8HYNWhxsRQcenAY=
+github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1.0.20260630133552-7d3a1fe9451f/go.mod h1:veHe4u3xEpl0TBV+wX0AFJWOsnteNPOhNklRbYf3d+k=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -41,7 +41,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.76 h1:mrdLPj8ujM6eIKGtd1PkkuCIodpFFDM42Cfm0YODkIM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.76/go.mod h1:7V2BQeHnVAQwhCnCPJ977giCeGDiywVewWF+8vkpPlc=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 h1:3DyzQ30OHt3wiOZVL1se2g1PAPJIU7+tMUyvfMUj1dY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.76/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.78 h1:jgqg4gyu2BaYW9L6uzEtGLf8GNREwk/z4UFdwt5F3pE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.78/go.mod h1:VjuVda6m2qGkpCVfrFkpTGyvkdlZ2N5/yfo89tujlg8=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.78 h1:PC3yNs51cX5LZ7U57a7xielBcoXB3xnV+rXD8V0H0DQ=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.78/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=


### PR DESCRIPTION
Extracted from the userspace BPF branch: independent of the feature. Supersedes #148.

Picks up `AttachUprobeWithOpts` / `AttachURetprobeWithOpts`, added upstream in aquasecurity/libbpfgo `7d3a1fe945`. Bumps both the Go module (`v0.10.0-libbpf-1.5.1` pseudo-version) and the `libbpfgo` git submodule to the same commit, so the Go bindings and the vendored static libbpf stay in sync. The submodule's libbpf moves to `f5dcbae7`, still on the 1.5.x line. The upcoming userspace BPF (bpftime) mode attaches single uprobes with cookies through this API.

Verified: kernel-mode build against the rebuilt static libbpf, full test suite passing.