### PR TITLE
fix(trace,probe): detach uprobes on event buffer init failure

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -152,7 +152,9 @@ func (p *Probe) CloseEventBuf() {
 // already stopped.
 func (p *Probe) CloseBPFMod() {
 	for _, link := range p.links {
-		link.Destroy()
+		if err := link.Destroy(); err != nil {
+			p.logger.Warn().Err(err).Msg("failed to destroy BPF link")
+		}
 	}
 	p.links = nil
 	if p.bpfMod != nil {

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -116,6 +116,11 @@ func (t *UserTracer) Run(ctx context.Context) error {
 	// Attach one uprobe per function to trace.
 	t.logger.Debug().Msg("attaching trace to selected functions")
 	t.attachProbe(ctx)
+	// Defers run LIFO: CloseBPFMod must be registered before CloseEventBuf so
+	// it runs second, after CloseEventBuf stops the ring buffer poll goroutine.
+	// Registering it right after attach also detaches the uprobes when
+	// InitEventBuf fails.
+	defer t.probe.CloseBPFMod()
 
 	feedCh := make(chan []byte, feedChBufSize)
 
@@ -123,9 +128,6 @@ func (t *UserTracer) Run(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "error initializing probe events buffer")
 	}
-	// Defers run LIFO: CloseBPFMod must be added first so it runs second,
-	// after CloseEventBuf stops the ring buffer poll goroutine.
-	defer t.probe.CloseBPFMod()
 	defer t.probe.CloseEventBuf()
 	// Because it is blocking, run ring_buffer__poll() in a non-locked goroutine,
 	// hence outside of InitEventBuf(), because of CGO callback from C which can make
@@ -230,7 +232,7 @@ func (t *UserTracer) handleEvent(data []byte) {
 	}
 	fun, ok := t.tracee.funcs[event.Cookie]
 	if !ok {
-		t.logger.Err(ErrFuncNotFoundForCookie).Msg("failed getting function from cookie")
+		t.logger.Err(ErrFuncNotFoundForCookie).Uint64("cookie", uint64(event.Cookie)).Msg("failed getting function from cookie")
 	}
 
 	if _, ok := t.ack.Load(event.Cookie); !ok {


### PR DESCRIPTION
Extracted from the userspace BPF branch: these fixes apply to kernel mode too.

- Register the `CloseBPFMod` defer right after attaching the probes. Before, if `InitEventBuf` failed, `Run` returned without destroying the BPF links, leaving the uprobes attached until process exit. The defer order relative to `CloseEventBuf` is unchanged (LIFO), so the module still closes after the poll goroutine stops.
- Log BPF link destroy failures instead of ignoring them.
- Include the cookie in the function-not-found event log.