### PR TITLE
fix(makefile): test the submodule .git link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(PROGRAM)/bpf: $(OUTPUT) $(VMLINUXH)
 
 .PHONY: $(foreach compile_mode,$(COMPILE_MODES),$(LIBBPFGO)-$(compile_mode))
 $(foreach compile_mode,$(COMPILE_MODES),$(LIBBPFGO)-$(compile_mode)):
-	[ -d $(LIBBPFGO)/.git ] || $(git) submodule update --init --recursive
+	[ -e $(LIBBPFGO)/.git ] || $(git) submodule update --init --recursive
 	make -C $(LIBBPFGO) $@
 
 .PHONY: $(BPFTOOL)


### PR DESCRIPTION
Follow-up to #158. In modern submodule layouts `.git` is a file pointing at the gitdir, so `[ -d ]` never passes and `git submodule update` runs on every build; in a container build from a git worktree it fails outright, since the worktree's gitdir is outside the bind mount.

Verified: with this fix, `make xcover-container` completes end to end from a worktree on an SELinux host (the in-container `libbpfgo-static` skips git and reuses the host-initialized submodule).