### PR TITLE
docs: document userspace BPF mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,28 @@ $ xcover stop
 
 The coverage report will be available as `xcover-report.json` after stopping the profiler.
 
+## Userspace BPF Mode (Experimental)
+
+xcover can run its BPF programs entirely in userspace through the
+[bpftime](https://github.com/eunomia-bpf/bpftime) runtime, removing the kernel
+trap on every traced function call. In benchmarks this cuts per-call overhead
+by roughly 65% on the hot path, and it runs unprivileged (no `CAP_BPF`).
+
+Build the dedicated binary and enable the mode with the `--userspace-bpf`
+flag; the tracee needs the bpftime agent preloaded:
+
+```shell
+$ make xcover-userspace
+$ ./xcover-userspace run --detach --path /path/to/bin --userspace-bpf
+$ ./xcover-userspace wait
+$ LD_PRELOAD=$(./xcover-userspace agent extract) /path/to/bin test_1
+$ ./xcover-userspace stop
+```
+
+The tracee must be dynamically linked against glibc; setuid binaries are not
+supported. See [the userspace BPF guide](docs/xcover_userspace_bpf.md) for how
+it works, requirements, and the full list of limitations.
+
 ## CLI Reference
 
 ## xcover

--- a/docs/xcover_userspace_bpf.md
+++ b/docs/xcover_userspace_bpf.md
@@ -4,8 +4,9 @@ xcover can optionally run BPF programs entirely in userspace via the
 [bpftime](https://github.com/eunomia-bpf/bpftime) runtime, eliminating the
 kernel trap cost on every traced function call.
 
-> **Status:** this is an experimental PoC. Real-world performance numbers have
-> not been collected yet.
+> **Status:** experimental. Benchmarks (see `benchmark/`) measure a ~65% lower
+> per-call overhead on the hit path and ~63% on the miss path compared to
+> kernel uprobes.
 
 ## How it works
 
@@ -96,6 +97,12 @@ uses a dynamic linker.
   `LD_PRELOAD` is silently ignored and the agent is never loaded.
 - Pure Go binaries (`CGO_ENABLED=0`): same reason - Go's internal linker
   produces a static binary with no `ld.so` dependency.
+- musl-linked binaries (e.g. Alpine). The shipped agent is built against
+  glibc and musl's loader fails to relocate it (`__libc_single_threaded`,
+  `getcontext` and other glibc-only symbols are missing). An agent built
+  against musl would lift this.
+- setuid/setgid binaries. The dynamic linker ignores `LD_PRELOAD` for
+  privileged executables (secure-execution mode).
 
 For unsupported binary types, fall back to kernel uprobe mode (default). This
 is not a regression: kernel uprobes work on any ELF binary regardless of


### PR DESCRIPTION
Follow-up to #111, which merged before this landed on the branch.

- README: add a Userspace BPF Mode section with the `make xcover-userspace` build target, the `--userspace-bpf` workflow (run, wait, agent extract via `LD_PRELOAD`, stop), the measured ~65% hot-path overhead reduction, and a link to the guide.
- Guide: replace the stale "no performance numbers yet" note with the measured figures (-65% hit, -63% miss vs kernel uprobes), and add the two verified unsupported cases to Binary support: musl (the glibc-built agent fails relocation under musl's loader) and setuid/setgid (secure-execution mode ignores `LD_PRELOAD`).