### PR TITLE
build(bpftime): apply patches with patch(1) and fix commit pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,18 +182,24 @@ bpftime-libs:
 			patch -p1 -d $(BPFTIME_DIR) < $$p || exit 1; \
 		done; \
 	fi
+	# Build with the system compiler. -include cstdint works around LLVM 18
+	# headers missing it under newer libstdc++; -include sys/syscall.h works
+	# around bpftime relying on transitive __NR_bpf exposure dropped by newer
+	# glibc. Both are no-ops on older toolchains.
 	cmake -B $(BPFTIME_BUILD) -S $(BPFTIME_DIR) \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBPFTIME_UBPF_JIT=ON \
 		-DBPFTIME_LLVM_JIT=ON \
 		-DCMAKE_EXE_LINKER_FLAGS=-no-pie \
-		$(if $(LLVM18_PREFIX),-DLLVM_DIR=$(LLVM18_PREFIX)/lib/cmake/llvm) \
-		$(if $(LLVM18_PREFIX),-DCMAKE_C_COMPILER=$(LLVM18_PREFIX)/bin/clang) \
-		$(if $(LLVM18_PREFIX),-DCMAKE_CXX_COMPILER=$(LLVM18_PREFIX)/bin/clang++)
+		-DCMAKE_CXX_FLAGS="-include cstdint -include sys/syscall.h" \
+		$(if $(LLVM18_PREFIX),-DLLVM_DIR=$(LLVM18_PREFIX)/lib/cmake/llvm)
+	# Build only the two runtime libraries xcover embeds. This skips the
+	# bpftime-vm CLI, whose vendored libbpf does not compile under GCC 14+.
 	# Prepend llvm@18 (and fallback llvm-config) libdir so bpftool can resolve
 	# libLLVM.so at skel.h generation time.
 	LD_LIBRARY_PATH="$(LLVM18_PREFIX)/lib:$$(llvm-config --libdir 2>/dev/null):$$LD_LIBRARY_PATH" \
-		cmake --build $(BPFTIME_BUILD) --parallel
+		cmake --build $(BPFTIME_BUILD) --parallel \
+			--target bpftime-syscall-server bpftime-agent
 	mkdir -p $(BPFTIME_LIBS_DST)
 	cp $(BPFTIME_BUILD)/runtime/syscall-server/libbpftime-syscall-server.so \
 		$(BPFTIME_LIBS_DST)/bpftime-syscall-server.so

--- a/Makefile
+++ b/Makefile
@@ -162,11 +162,10 @@ xcover-container-userspace:
 BPFTIME_GIT      := https://github.com/eunomia-bpf/bpftime.git
 # Pinned to 5bf24b21af85 (2026-05-25): includes fix for bpf_link attach_cookie and
 # FEAT_PERF_LINK detection (PR #570). Bump this when pulling in further upstream fixes.
-BPFTIME_COMMIT   := 5bf24b21af856f79a6aa3bd8da6e4dcfbe1d95d4
+BPFTIME_COMMIT   := 5bf24b21af85efee0443710c4dd4a34f3b92e0a2
 BPFTIME_DIR      := bpftime-src
 BPFTIME_BUILD    := $(BPFTIME_DIR)/build
 BPFTIME_LIBS_DST := pkg/bpftime/libs
-BPFTIME_LIBBPF_C := $(BPFTIME_DIR)/third_party/bpftool/libbpf/src/libbpf.c
 # Prefer brew-installed llvm@18 (compatible with bpftime's LLVM JIT) over any
 # system LLVM. If llvm@18 is not installed, LLVM18_PREFIX is empty and the
 # cmake flags below are omitted, falling back to whatever cmake finds.
@@ -178,94 +177,11 @@ bpftime-libs:
 		$(git) clone --recurse-submodules $(BPFTIME_GIT) $(BPFTIME_DIR); \
 		$(git) -C $(BPFTIME_DIR) checkout $(BPFTIME_COMMIT); \
 		$(git) -C $(BPFTIME_DIR) submodule update --init --recursive; \
+		for p in patches/bpftime/*.patch; do \
+			echo "Applying $$p"; \
+			patch -p1 -d $(BPFTIME_DIR) < $$p || exit 1; \
+		done; \
 	fi
-	# Fix const-qualifier discards in bpftool-bundled libbpf, hard errors under GCC 14+.
-	# Upstream fix: libbpf commit f5dcbae (2026-03-12). Remove once bpftime bumps its
-	# bpftool submodule past that date.
-	python3 -c "\
-f = open('$(BPFTIME_LIBBPF_C)', 'r'); s = f.read(); f.close(); \
-s = s.replace('\tchar *res;\n',                                               '\tconst char *res;\n',           1); \
-s = s.replace('\t\tchar sym_trim[256], *psym_trim = sym_trim, *sym_sfx;\n',   '\t\tchar sym_trim[256], *psym_trim = sym_trim;\n\t\tconst char *sym_sfx;\n', 1); \
-s = s.replace('\t\t\tchar *next_path;\n',                                     '\t\t\tconst char *next_path;\n', 1); \
-f = open('$(BPFTIME_LIBBPF_C)', 'w'); f.write(s); f.close()"
-	# Fix conflicting declaration of bpf_stream_vprintk in bpftool-bundled libbpf vs
-	# vmlinux.h generated from kernel 6.15+. The bundled libbpf declares the helper
-	# with 5 params; the kernel BTF declares it with 4. Drop the bundled decl; the
-	# bpftool skeleton sources do not call bpf_stream_printk/bpf_stream_vprintk.
-	# Remove once bpftime bumps its bpftool submodule past bpftool commit 640fb7ceed18
-	# (2025-11-10).
-	python3 -c "\
-import re; \
-bpf_h = '$(BPFTIME_DIR)/third_party/bpftool/libbpf/src/bpf_helpers.h'; \
-f = open(bpf_h, 'r'); s = f.read(); f.close(); \
-s = re.sub(r'extern int bpf_stream_vprintk\b[^;]+;\s*', '', s, count=1); \
-f = open(bpf_h, 'w'); f.write(s); f.close()"
-	# Fix __destruct_shm crash when injected_pids is null (LD_PRELOAD agent path).
-	# open_type is set in the member initializer list before the constructor body,
-	# so even a partially-constructed bpftime_shm has open_type == SHM_OPEN_ONLY.
-	# If the SHM open fails (or is never initialised), injected_pids stays null and
-	# erase() crashes the tracee on exit.  Guard both sides defensively.
-	python3 -c "\
-shm = '$(BPFTIME_DIR)/runtime/src/bpftime_shm_internal.cpp'; \
-f = open(shm, 'r'); s = f.read(); f.close(); \
-s = s.replace( \
-	'\tif (bpftime::shm_holder.global_shared_memory.get_open_type() ==\n\t    bpftime::shm_open_type::SHM_OPEN_ONLY) {', \
-	'\tif (global_shm_initialized &&\n\t    bpftime::shm_holder.global_shared_memory.get_open_type() ==\n\t    bpftime::shm_open_type::SHM_OPEN_ONLY) {', \
-	1); \
-s = s.replace( \
-	'void bpftime_shm::remove_pid_from_alive_agent_set(int pid)\n{\n\tinjected_pids->erase(pid);\n}', \
-	'void bpftime_shm::remove_pid_from_alive_agent_set(int pid)\n{\n\tif (injected_pids != nullptr) {\n\t\tinjected_pids->erase(pid);\n\t}\n}', \
-	1); \
-f = open(shm, 'w'); f.write(s); f.close()"
-	# Fix OOB crash in handler_manager when the OS fd value exceeds max_fd_count.
-	# set_handler() calls is_allocated() which returns false for fd >= size, then
-	# does handlers[fd] — an unchecked OOB write.  get_handler() / operator[] also
-	# index directly without a bounds check.  Add guards to all three so that
-	# exhausting the handler slots returns -ENOSPC (or an unused_handler sentinel)
-	# instead of crashing the tracer process with a SIGSEGV.
-	# Also patch open_fake_fd() to close the real /dev/null fd and return -1 when
-	# it would exceed the array bounds, avoiding an OS fd leak on top of the crash.
-	python3 -c "\
-hm = '$(BPFTIME_DIR)/runtime/src/handler/handler_manager.cpp'; \
-f = open(hm, 'r'); s = f.read(); f.close(); \
-s = s.replace( \
-	'int handler_manager::set_handler(int fd, handler_variant &&handler,\n\t\t\t\t managed_shared_memory &memory)\n{\n\tif (is_allocated(fd)) {', \
-	'int handler_manager::set_handler(int fd, handler_variant &&handler,\n\t\t\t\t managed_shared_memory &memory)\n{\n\tif (fd < 0 || (std::size_t)fd >= handlers.size()) {\n\t\tSPDLOG_ERROR(\"set_handler: fd {} out of range [0, {})\", fd, handlers.size());\n\t\treturn -ENOSPC;\n\t}\n\tif (is_allocated(fd)) {', \
-	1); \
-s = s.replace( \
-	'const handler_variant &handler_manager::get_handler(int fd) const\n{\n\treturn handlers[fd];\n}', \
-	'const handler_variant &handler_manager::get_handler(int fd) const\n{\n\tstatic const handler_variant oob_handler = unused_handler{};\n\tif (fd < 0 || (std::size_t)fd >= handlers.size()) return oob_handler;\n\treturn handlers[fd];\n}', \
-	1); \
-s = s.replace( \
-	'const handler_variant &handler_manager::operator[](int idx) const\n{\n\treturn handlers[idx];\n}', \
-	'const handler_variant &handler_manager::operator[](int idx) const\n{\n\tstatic const handler_variant oob_handler = unused_handler{};\n\tif (idx < 0 || (std::size_t)idx >= handlers.size()) return oob_handler;\n\treturn handlers[idx];\n}', \
-	1); \
-f = open(hm, 'w'); f.write(s); f.close()"
-	python3 -c "\
-shm = '$(BPFTIME_DIR)/runtime/src/bpftime_shm_internal.cpp'; \
-f = open(shm, 'r'); s = f.read(); f.close(); \
-s = s.replace( \
-	'int bpftime_shm::open_fake_fd()\n{\n\tint fd = open(\"/dev/null\", O_RDONLY);\n\tint cnt = 5;\n\twhile (fd <= 2 && fd >= 0 && --cnt > 0) {\n\t\tfd = dup(fd);\n\t}\n\treturn fd;\n}', \
-	'int bpftime_shm::open_fake_fd()\n{\n\tint fd = open(\"/dev/null\", O_RDONLY);\n\tint cnt = 5;\n\twhile (fd <= 2 && fd >= 0 && --cnt > 0) {\n\t\tfd = dup(fd);\n\t}\n\tif (fd >= 0 && (std::size_t)fd >= manager->size()) {\n\t\tclose(fd);\n\t\terrno = ENOSPC;\n\t\treturn -1;\n\t}\n\treturn fd;\n}', \
-	1); \
-f = open(shm, 'w'); f.write(s); f.close()"
-	# Fix perf event handler slot leak on BPF link close.
-	# When a BPF_PERF_EVENT link is destroyed (close(link_fd)), libbpf relies on
-	# the kernel to drop the perf event reference. In bpftime userspace that never
-	# happens: clear_id_at() for a bpf_link_handler only freed the link slot,
-	# leaving the perf event handler permanently allocated — one slot leaked per
-	# uprobe per attach/detach cycle, exhausting the pool across benchmark rounds.
-	# Fix: cascade the clear to the attached perf event handler. The link slot is
-	# set to unused_handler first to prevent infinite recursion (the perf event
-	# cleanup scans for linked handlers by attach_target_id).
-	python3 -c "\
-hm = '$(BPFTIME_DIR)/runtime/src/handler/handler_manager.cpp'; \
-f = open(hm, 'r'); s = f.read(); f.close(); \
-s = s.replace( \
-	'\t\t\t\tclear_id_at(i, memory);\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n\thandlers[fd] = unused_handler();\n}', \
-	'\t\t\t\tclear_id_at(i, memory);\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t} else if (std::holds_alternative<bpf_link_handler>(handlers[fd])) {\n\t\tauto target_fd =\n\t\t\tstd::get<bpf_link_handler>(handlers[fd]).attach_target_id;\n\t\thandlers[fd] = unused_handler();\n\t\tSPDLOG_DEBUG(\"Destroying link handler {}, cascading to perf event {}\", fd, target_fd);\n\t\tclear_id_at(target_fd, memory);\n\t\treturn;\n\t}\n\thandlers[fd] = unused_handler();\n}', \
-	1); \
-f = open(hm, 'w'); f.write(s); f.close()"
 	cmake -B $(BPFTIME_BUILD) -S $(BPFTIME_DIR) \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBPFTIME_UBPF_JIT=ON \

--- a/patches/bpftime/0001-fix-null-injected_pids-crash-on-tracee-exit.patch
+++ b/patches/bpftime/0001-fix-null-injected_pids-crash-on-tracee-exit.patch
@@ -1,6 +1,8 @@
+diff --git a/runtime/src/bpftime_shm_internal.cpp b/runtime/src/bpftime_shm_internal.cpp
+index 856bb8a..d42bc13 100644
 --- a/runtime/src/bpftime_shm_internal.cpp
 +++ b/runtime/src/bpftime_shm_internal.cpp
-@@ -72,7 +72,8 @@
+@@ -72,7 +72,8 @@ static __attribute__((destructor(65535))) void __destruct_shm()
  {
  	// This usually indicates that the living shared memory object is used
  	// by an agent instance
@@ -10,7 +12,7 @@
  	    bpftime::shm_open_type::SHM_OPEN_ONLY) {
  		// Try our best to remove the current pid from alive agent's set
  		int self_pid = getpid();
-@@ -1103,7 +1104,9 @@
+@@ -1103,7 +1104,9 @@ void bpftime_shm::add_pid_into_alive_agent_set(int pid)
  }
  void bpftime_shm::remove_pid_from_alive_agent_set(int pid)
  {

--- a/patches/bpftime/0002-fix-handler-manager-oob-and-open-fake-fd-leak.patch
+++ b/patches/bpftime/0002-fix-handler-manager-oob-and-open-fake-fd-leak.patch
@@ -1,6 +1,24 @@
+diff --git a/runtime/src/bpftime_shm_internal.cpp b/runtime/src/bpftime_shm_internal.cpp
+index d42bc13..6b0bd37 100644
+--- a/runtime/src/bpftime_shm_internal.cpp
++++ b/runtime/src/bpftime_shm_internal.cpp
+@@ -550,6 +550,11 @@ int bpftime_shm::open_fake_fd()
+ 	while (fd <= 2 && fd >= 0 && --cnt > 0) {
+ 		fd = dup(fd);
+ 	}
++	if (fd >= 0 && (std::size_t)fd >= manager->size()) {
++		close(fd);
++		errno = ENOSPC;
++		return -1;
++	}
+ 	return fd;
+ }
+ 
+diff --git a/runtime/src/handler/handler_manager.cpp b/runtime/src/handler/handler_manager.cpp
+index a834022..7a44534 100644
 --- a/runtime/src/handler/handler_manager.cpp
 +++ b/runtime/src/handler/handler_manager.cpp
-@@ -34,11 +34,15 @@
+@@ -34,11 +34,15 @@ handler_manager::~handler_manager()
  
  const handler_variant &handler_manager::get_handler(int fd) const
  {
@@ -16,7 +34,7 @@
  	return handlers[idx];
  }
  std::size_t handler_manager::size() const
-@@ -59,6 +63,10 @@
+@@ -59,6 +63,10 @@ int handler_manager::set_handler_at_empty_slot(handler_variant &&handler,
  int handler_manager::set_handler(int fd, handler_variant &&handler,
  				 managed_shared_memory &memory)
  {
@@ -27,17 +45,3 @@
  	if (is_allocated(fd)) {
  		SPDLOG_ERROR("set_handler failed for fd {} aleady exists", fd);
  		return -EEXIST;
---- a/runtime/src/bpftime_shm_internal.cpp
-+++ b/runtime/src/bpftime_shm_internal.cpp
-@@ -549,6 +549,11 @@
- 	while (fd <= 2 && fd >= 0 && --cnt > 0) {
- 		fd = dup(fd);
- 	}
-+	if (fd >= 0 && (std::size_t)fd >= manager->size()) {
-+		close(fd);
-+		errno = ENOSPC;
-+		return -1;
-+	}
- 	return fd;
- }
- 

--- a/patches/bpftime/0003-fix-link-close-leaks-perf-event-handler.patch
+++ b/patches/bpftime/0003-fix-link-close-leaks-perf-event-handler.patch
@@ -1,20 +1,12 @@
+diff --git a/runtime/src/handler/handler_manager.cpp b/runtime/src/handler/handler_manager.cpp
+index 7a44534..83015f2 100644
 --- a/runtime/src/handler/handler_manager.cpp
 +++ b/runtime/src/handler/handler_manager.cpp
-@@ -112,6 +112,19 @@ void handler_manager::clear_id_at(int fd, managed_shared_memory &memory)
- 				clear_id_at(i, memory);
+@@ -136,6 +136,13 @@ void handler_manager::clear_id_at(int fd, managed_shared_memory &memory)
+ 				}
  			}
  		}
 +	} else if (std::holds_alternative<bpf_link_handler>(handlers[fd])) {
-+		// When a BPF_PERF_EVENT link is destroyed, libbpf relies on the
-+		// kernel to drop the perf event reference via the link fd. In
-+		// userspace (bpftime) that doesn't happen: closing the link fd
-+		// only frees the link handler slot, leaving the perf event
-+		// handler permanently allocated and leaking one slot per uprobe
-+		// per attach/detach cycle.
-+		//
-+		// Fix: cascade the close to the attached perf event handler.
-+		// Clear the link slot first to prevent infinite recursion (the
-+		// perf event cleanup scans for linked handlers by attach_target_id).
 +		auto target_fd =
 +			std::get<bpf_link_handler>(handlers[fd]).attach_target_id;
 +		handlers[fd] = unused_handler();

--- a/patches/bpftime/0004-fix-gcc14-const-qualifier-in-bundled-libbpf.patch
+++ b/patches/bpftime/0004-fix-gcc14-const-qualifier-in-bundled-libbpf.patch
@@ -1,22 +1,32 @@
+diff --git a/third_party/bpftool/libbpf/src/libbpf.c b/third_party/bpftool/libbpf/src/libbpf.c
+index fe4fc54..3a0220e 100644
 --- a/third_party/bpftool/libbpf/src/libbpf.c
 +++ b/third_party/bpftool/libbpf/src/libbpf.c
-@@ -x,x +x,x @@
+@@ -8202,7 +8202,7 @@ static int kallsyms_cb(unsigned long long sym_addr, char sym_type,
+ 	struct bpf_object *obj = ctx;
+ 	const struct btf_type *t;
+ 	struct extern_desc *ext;
 -	char *res;
 +	const char *res;
-
-@@ -x,x +x,x @@
+ 
+ 	res = strstr(sym_name, ".llvm.");
+ 	if (sym_type == 'd' && res)
+@@ -11510,7 +11510,8 @@ static int avail_kallsyms_cb(unsigned long long sym_addr, char sym_type,
+ 		 *
+ 		 *   [0] fb6a421fb615 ("kallsyms: Match symbols exactly with CONFIG_LTO_CLANG")
+ 		 */
 -		char sym_trim[256], *psym_trim = sym_trim, *sym_sfx;
 +		char sym_trim[256], *psym_trim = sym_trim;
 +		const char *sym_sfx;
-
-@@ -x,x +x,x @@
+ 
+ 		if (!(sym_sfx = strstr(sym_name, ".llvm.")))
+ 			return 0;
+@@ -12095,7 +12096,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
 -			char *next_path;
 +			const char *next_path;
-
-Fixes const-qualifier discards in the bpftool-bundled libbpf that are
-hard errors under GCC 14+. Three string pointer variables are assigned
-from string literals or const-returning functions but were declared as
-non-const char *.
-
-Upstream fix: libbpf commit f5dcbae (2026-03-12).
-Remove once bpftime bumps its bpftool submodule past that date.
+ 			int seg_len;
+ 
+ 			if (s[0] == ':')

--- a/patches/bpftime/0005-fix-bpf-stream-vprintk-conflicting-decl.patch
+++ b/patches/bpftime/0005-fix-bpf-stream-vprintk-conflicting-decl.patch
@@ -1,13 +1,14 @@
+diff --git a/third_party/bpftool/libbpf/src/bpf_helpers.h b/third_party/bpftool/libbpf/src/bpf_helpers.h
+index 80c0285..a2f55e8 100644
 --- a/third_party/bpftool/libbpf/src/bpf_helpers.h
 +++ b/third_party/bpftool/libbpf/src/bpf_helpers.h
-@@ -x,x +x,x @@
--extern int bpf_stream_vprintk(...); /* 5-param variant */
-
-Removes the conflicting declaration of bpf_stream_vprintk from the
-bpftool-bundled libbpf. The bundled header declares the helper with 5
-parameters; vmlinux.h generated from kernel 6.15+ declares it with 4.
-The bpftool skeleton sources do not call bpf_stream_printk or
-bpf_stream_vprintk, so dropping the bundled declaration is safe.
-
-Upstream fix: bpftool commit 640fb7ceed18 (2025-11-10).
-Remove once bpftime bumps its bpftool submodule past that date.
+@@ -315,9 +315,6 @@ enum libbpf_tristate {
+ 			  ___param, sizeof(___param));		\
+ })
+ 
+-extern int bpf_stream_vprintk(int stream_id, const char *fmt__str, const void *args,
+-			      __u32 len__sz, void *aux__prog) __weak __ksym;
+-
+ #define bpf_stream_printk(stream_id, fmt, args...)				\
+ ({										\
+ 	static const char ___fmt[] = fmt;					\

--- a/patches/bpftime/README.md
+++ b/patches/bpftime/README.md
@@ -3,8 +3,8 @@
 Upstream: <https://github.com/eunomia-bpf/bpftime>
 Pinned commit: `5bf24b21af85`
 
-Each patch file corresponds to one bug fix. They are applied inline during
-`make bpftime-libs` via Python string replacements in the root `Makefile`.
+Each patch file corresponds to one bug fix. `make bpftime-libs` applies them
+with `patch -p1` right after cloning the pinned bpftime tree.
 Once the fixes are validated, each should be opened as a separate PR upstream.
 
 ## 0001 — null `injected_pids` crash on tracee exit


### PR DESCRIPTION
Follow-up to #111, cleaning up the bpftime patching mechanism.

Problems found:
- The Makefile applied the fixes through inline Python string replacements; `patches/bpftime/` was a parallel copy that had drifted: `0003` carried comment lines the build never applied, and `0004`/`0005` were pseudo-diffs (placeholder `@@ -x,x +x,x @@` hunk headers, paraphrased removal lines) that `patch(1)` could not apply.
- `BPFTIME_COMMIT` pinned `5bf24b21af856f79a6aa3bd8da6e4dcfbe1d95d4`, which does not exist upstream (the 12-char prefix is right, the tail is not). A fresh `make bpftime-libs` failed at `git checkout`.

Changes:
- `patches/bpftime/*.patch` are now the single source of truth: all five regenerated as real diffs of the pinned tree; the Makefile applies them with `patch -p1` right after cloning, deleting ~90 lines of inline Python.
- Pin corrected to `5bf24b21af85efee0443710c4dd4a34f3b92e0a2` (verified reachable from upstream master).

Verification: on a fresh recursive clone, checkout of the corrected pin plus the five patches produces sources byte-identical to the tree that built the shipped libraries (compared `bpftime_shm_internal.cpp`, `handler_manager.cpp`, `libbpf.c`, `bpf_helpers.h`).