### PR TITLE
refactor: remove dead code (duplicate FuncName, legacy ShouldIncludeSymbol)

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -18,14 +18,7 @@ import (
 	"github.com/maxgio92/xcover/pkg/trace"
 )
 
-const (
-	funNameLen = 64
-	CmdName    = "run"
-)
-
-type FuncName struct {
-	Name [funNameLen]byte
-}
+const CmdName = "run"
 
 type Options struct {
 	comm string

--- a/pkg/trace/should_include_test.go
+++ b/pkg/trace/should_include_test.go
@@ -1,0 +1,23 @@
+package trace
+
+import (
+	"debug/elf"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldInclude(t *testing.T) {
+	fooSym := elf.Symbol{
+		Name: "main.fooFunction",
+		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
+	}
+	require.True(t, shouldInclude(fooSym, "^main.fooFunction$", "", nil, nil))
+
+	runtimeSym := elf.Symbol{
+		Name: "runtime.sched",
+		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
+	}
+	require.True(t, shouldInclude(runtimeSym, "", "", nil, nil))
+	require.False(t, shouldInclude(runtimeSym, "", "^runtime.", nil, nil))
+}

--- a/pkg/trace/tracee.go
+++ b/pkg/trace/tracee.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"context"
-	"debug/elf"
 
 	"github.com/pkg/errors"
 )
@@ -103,12 +102,6 @@ func (t *UserTracee) validate() error {
 		return ErrExePathEmpty
 	}
 	return nil
-}
-
-// ShouldIncludeSymbol reports whether sym passes the tracee's include/exclude filters.
-// Kept for backward compatibility; prefer the package-level shouldInclude for new code.
-func (t *UserTracee) ShouldIncludeSymbol(sym elf.Symbol) bool {
-	return shouldInclude(sym, t.symPatternInclude, t.symPatternExclude, t.symBindInclude, t.symBindExclude)
 }
 
 // GetFuncProbes returns the uprobe attach offsets and their corresponding

--- a/pkg/trace/tracee_test.go
+++ b/pkg/trace/tracee_test.go
@@ -1,7 +1,6 @@
 package trace_test
 
 import (
-	"debug/elf"
 	"os"
 	"path"
 	"testing"
@@ -12,12 +11,14 @@ import (
 	"github.com/maxgio92/xcover/pkg/trace"
 )
 
+//nolint:unused // consumed by integration-tagged tests in this package (e.g. resolver_integration_test.go)
 var (
 	testData         = "testdata"
 	testBinary       = path.Join(testData, "gotest")
 	testExcludedSyms = "^runtime.text$|^internal/cpu.Initialize$"
-	testLogger       = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
 )
+
+var testLogger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
 
 func TestNewUserTracee_Defaults(t *testing.T) {
 	tracee := trace.NewUserTracee()
@@ -31,31 +32,4 @@ func TestUserTracee_Validate(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exe path is empty")
 	require.ErrorIs(t, err, trace.ErrExePathEmpty)
-}
-
-func TestUserTracee_IncludeExclude(t *testing.T) {
-	tracee := trace.NewUserTracee(
-		trace.WithTraceeSymPatternInclude("^main.fooFunction$"),
-	)
-
-	sym := elf.Symbol{
-		Name: "main.fooFunction",
-		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
-	}
-
-	include := tracee.ShouldIncludeSymbol(sym)
-	require.True(t, include)
-
-	sym = elf.Symbol{
-		Name: "runtime.sched",
-		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
-	}
-
-	tracee = trace.NewUserTracee()
-	require.True(t, tracee.ShouldIncludeSymbol(sym))
-
-	tracee = trace.NewUserTracee(
-		trace.WithTraceeSymPatternExclude("^runtime."),
-	)
-	require.False(t, tracee.ShouldIncludeSymbol(sym))
 }

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	funNameLen                     = 64
 	bpfMaxBufferSize               = 1024                 // Maximum size of bpf_attr needed to batch offsets for uprobe_multi attachments.
 	bpfUprobeMultiAttachMaxOffsets = bpfMaxBufferSize / 8 // 8 is the byte size of uint64 used to represent offsets.
 	HealthCheckSockPath            = "/tmp/xcover.sock"
@@ -29,10 +28,6 @@ var (
 	feedChBufSize  = 4096
 	ReportFileName = fmt.Sprintf("%s-report.json", settings.CmdName)
 )
-
-type FuncName struct {
-	Name [funNameLen]byte
-}
 
 type Event struct {
 	Cookie cookie


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 1 of 9).

Removes:
- Duplicate `FuncName` struct, identical and unreferenced in both `pkg/cmd/run/run.go` and `pkg/trace/tracer.go`.
- `UserTracee.ShouldIncludeSymbol`, explicitly marked legacy in favor of the package-level `shouldInclude`. Its only caller was a test, replaced with a direct unit test of `shouldInclude`.

No behavior change. Build, vet, and tests pass.