### PR TITLE
refactor: standardize error handling in pkg/cmd

### DIFF
--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/maxgio92/xcover/internal/settings"
@@ -22,17 +23,22 @@ func NewCommand(opts *options.Options) *cobra.Command {
 		Short:             fmt.Sprintf("Check the the %s profiler status", settings.CmdName),
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
-		Run:               o.Run,
+		RunE:              o.Run,
 	}
 
 	return cmd
 }
 
-func (o *Options) Run(cmd *cobra.Command, _ []string) {
+func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	if common.IsDaemonRunning() {
-		pidData, _ := os.ReadFile(settings.PidFile)
+		pidData, err := os.ReadFile(settings.PidFile)
+		if err != nil {
+			return errors.Wrap(err, "failed to read PID file")
+		}
 		fmt.Printf("%s is running (PID %s)\n", settings.CmdName, pidData)
 	} else {
 		fmt.Printf("%s is not running\n", settings.CmdName)
 	}
+
+	return nil
 }

--- a/pkg/cmd/stop/stop.go
+++ b/pkg/cmd/stop/stop.go
@@ -1,13 +1,13 @@
 package stop
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/maxgio92/xcover/internal/settings"
@@ -16,10 +16,10 @@ import (
 )
 
 var (
-	ErrNotRunningOrNotFound = fmt.Errorf("%s not running or PID file not found", settings.CmdName)
+	ErrNotRunningOrNotFound = errors.Errorf("%s not running or PID file not found", settings.CmdName)
 	ErrInvalidPIDFile       = errors.New("invalid PID file")
 	ErrProcessNotFound      = errors.New("process not found")
-	ErrFailedToStop         = fmt.Errorf("failed to stop %s", settings.CmdName)
+	ErrFailedToStop         = errors.Errorf("failed to stop %s", settings.CmdName)
 )
 
 type Options struct {

--- a/pkg/cmd/wait/wait.go
+++ b/pkg/cmd/wait/wait.go
@@ -22,7 +22,7 @@ import (
 const CmdName = "wait"
 
 var (
-	ErrNotRunning = errors.New(fmt.Sprintf("%s is not running", settings.CmdName))
+	ErrNotRunning = errors.Errorf("%s is not running", settings.CmdName)
 )
 
 type Options struct {

--- a/pkg/cmd/wait/wait.go
+++ b/pkg/cmd/wait/wait.go
@@ -81,11 +81,11 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 				time.Sleep(retryInterval)
 				continue
 			}
-			return fmt.Errorf("error checking socket: %w", err)
+			return errors.Wrap(err, "error checking socket")
 		}
 
 		if info.Mode()&os.ModeSocket == 0 {
-			return fmt.Errorf("path exists but is not a Unix socket: %s", o.socketPath)
+			return errors.Errorf("path exists but is not a Unix socket: %s", o.socketPath)
 		}
 
 		// Try to connect.


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 2 of 9).

- Converts `stop.go`'s stdlib `errors`/`fmt.Errorf` sentinels to `github.com/pkg/errors`, matching `run.go` and `wait.go`.
- Fixes `status.go` silently discarding the `os.ReadFile` error: now wrapped and returned.
- Fixes `wait.go`'s `errors.New(fmt.Sprintf(...))` in favor of `errors.Errorf(...)`.

No behavior change beyond the status.go error now surfacing instead of being swallowed. Build, vet, and tests pass.