### PR TITLE
refactor: consolidate PID/daemon lifecycle logic in pkg/cmd/common

### DIFF
--- a/pkg/cmd/common/common.go
+++ b/pkg/cmd/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"syscall"
@@ -8,13 +10,38 @@ import (
 	"github.com/maxgio92/xcover/internal/settings"
 )
 
-func IsDaemonRunning() bool {
+// ErrInvalidPID is returned by ReadPID when the PID file exists but its
+// content cannot be parsed as a PID. Callers should use errors.Is to detect
+// this case rather than inspecting the underlying parse error.
+var ErrInvalidPID = errors.New("invalid PID")
+
+// WritePID writes the given PID to the PID file.
+func WritePID(pid int) error {
+	return os.WriteFile(settings.PidFile, []byte(strconv.Itoa(pid)), 0644)
+}
+
+// ReadPID reads and parses the PID from the PID file.
+func ReadPID() (int, error) {
 	pidData, err := os.ReadFile(settings.PidFile)
 	if err != nil {
-		return false
+		return 0, err
 	}
 
 	pid, err := strconv.Atoi(string(pidData))
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrInvalidPID, err)
+	}
+
+	return pid, nil
+}
+
+// RemovePID removes the PID file.
+func RemovePID() error {
+	return os.Remove(settings.PidFile)
+}
+
+func IsDaemonRunning() bool {
+	pid, err := ReadPID()
 	if err != nil {
 		return false
 	}

--- a/pkg/cmd/common/common_test.go
+++ b/pkg/cmd/common/common_test.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maxgio92/xcover/internal/settings"
+)
+
+func withTempPidFile(t *testing.T) string {
+	t.Helper()
+
+	orig := settings.PidFile
+	settings.PidFile = filepath.Join(t.TempDir(), "test.pid")
+	t.Cleanup(func() { settings.PidFile = orig })
+
+	return settings.PidFile
+}
+
+func TestWriteReadRemovePID(t *testing.T) {
+	withTempPidFile(t)
+
+	if err := WritePID(1234); err != nil {
+		t.Fatalf("WritePID() error = %v", err)
+	}
+
+	pid, err := ReadPID()
+	if err != nil {
+		t.Fatalf("ReadPID() error = %v", err)
+	}
+	if pid != 1234 {
+		t.Fatalf("ReadPID() = %d, want 1234", pid)
+	}
+
+	if err := RemovePID(); err != nil {
+		t.Fatalf("RemovePID() error = %v", err)
+	}
+
+	if _, err := os.Stat(settings.PidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected PID file to be removed, stat err = %v", err)
+	}
+}
+
+func TestReadPID_Missing(t *testing.T) {
+	withTempPidFile(t)
+
+	_, err := ReadPID()
+	if err == nil {
+		t.Fatal("expected error reading missing PID file, got nil")
+	}
+	if errors.Is(err, ErrInvalidPID) {
+		t.Fatalf("expected a non-ErrInvalidPID error for a missing file, got %v", err)
+	}
+}
+
+func TestReadPID_Malformed(t *testing.T) {
+	path := withTempPidFile(t)
+
+	if err := os.WriteFile(path, []byte("not-a-pid"), 0644); err != nil {
+		t.Fatalf("failed to write malformed PID file: %v", err)
+	}
+
+	_, err := ReadPID()
+	if !errors.Is(err, ErrInvalidPID) {
+		t.Fatalf("ReadPID() error = %v, want wrapping ErrInvalidPID", err)
+	}
+}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -88,8 +88,8 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Store PID file.
-	os.WriteFile(settings.PidFile, []byte(strconv.Itoa(os.Getpid())), 0644)
-	defer os.Remove(settings.PidFile)
+	common.WritePID(os.Getpid())
+	defer common.RemovePID()
 
 	var err error
 	o.LogLevel, err = cmd.Flags().GetString("log-level")
@@ -197,7 +197,7 @@ func (o *Options) daemonize() error {
 	}
 
 	// Store PID file.
-	err = os.WriteFile(settings.PidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0644)
+	err = common.WritePID(cmd.Process.Pid)
 	if err != nil {
 		o.Logger.Error().Err(err).Msg("failed to write PID file")
 		return err

--- a/pkg/cmd/stop/stop.go
+++ b/pkg/cmd/stop/stop.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -41,14 +40,13 @@ func NewCommand(opts *options.Options) *cobra.Command {
 }
 
 func (o *Options) Run(cmd *cobra.Command, _ []string) error {
-	pidData, err := os.ReadFile(settings.PidFile)
+	pid, err := common.ReadPID()
 	if err != nil {
-		return ErrNotRunningOrNotFound
-	}
+		if errors.Is(err, common.ErrInvalidPID) {
+			return ErrInvalidPIDFile
+		}
 
-	pid, err := strconv.Atoi(string(pidData))
-	if err != nil {
-		return ErrInvalidPIDFile
+		return ErrNotRunningOrNotFound
 	}
 
 	process, err := os.FindProcess(pid)
@@ -65,7 +63,7 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	for i := 0; i < 50; i++ {
 		if !common.IsDaemonRunning() {
 			fmt.Printf("%s stopped (PID %d)\n", settings.CmdName, pid)
-			os.Remove(settings.PidFile)
+			common.RemovePID()
 
 			return nil
 		}
@@ -74,7 +72,7 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 
 	// Force kill if still running.
 	process.Kill()
-	os.Remove(settings.PidFile)
+	common.RemovePID()
 	fmt.Printf("%s force killed (PID %d)\n", settings.CmdName, pid)
 
 	return nil

--- a/pkg/cmd/stop/stop_test.go
+++ b/pkg/cmd/stop/stop_test.go
@@ -1,0 +1,47 @@
+package stop
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maxgio92/xcover/internal/settings"
+	"github.com/maxgio92/xcover/pkg/cmd/options"
+)
+
+func withTempPidFile(t *testing.T) string {
+	t.Helper()
+
+	orig := settings.PidFile
+	settings.PidFile = filepath.Join(t.TempDir(), "test.pid")
+	t.Cleanup(func() { settings.PidFile = orig })
+
+	return settings.PidFile
+}
+
+func TestRun_MissingPIDFile(t *testing.T) {
+	withTempPidFile(t)
+
+	o := &Options{options.NewOptions()}
+
+	err := o.Run(nil, nil)
+	if !errors.Is(err, ErrNotRunningOrNotFound) {
+		t.Fatalf("Run() error = %v, want ErrNotRunningOrNotFound", err)
+	}
+}
+
+func TestRun_MalformedPIDFile(t *testing.T) {
+	path := withTempPidFile(t)
+
+	if err := os.WriteFile(path, []byte("not-a-pid"), 0644); err != nil {
+		t.Fatalf("failed to write malformed PID file: %v", err)
+	}
+
+	o := &Options{options.NewOptions()}
+
+	err := o.Run(nil, nil)
+	if !errors.Is(err, ErrInvalidPIDFile) {
+		t.Fatalf("Run() error = %v, want ErrInvalidPIDFile", err)
+	}
+}


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 3 of 9).

Adds `WritePID`, `ReadPID`, and `RemovePID` to `pkg/cmd/common`, and has `run.go` and `stop.go` use them instead of duplicating PID file read/write/parse logic. `IsDaemonRunning` now delegates to `ReadPID` internally, signature unchanged.

`stop.go` distinguishes a missing PID file from a malformed one via a new `ErrInvalidPID` sentinel (`errors.Is`) rather than reaching into `strconv`'s error type, avoiding a leaky cross-package coupling. Added unit tests for the new helpers and for stop's missing/malformed PID file branches.

No CLI-visible behavior change. Build, vet, and tests pass.