### PR TITLE
refactor: remove redundant log-level parsing in run and wait

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -41,7 +41,7 @@ At the end of your tests, the profiler can be stopped and a report being collect
 
 			logLevel, err := log.ParseLevel(o.LogLevel)
 			if err != nil {
-				o.Logger.Err(err).Msg("invalid log level")
+				return fmt.Errorf("invalid log level %q: %w", o.LogLevel, err)
 			}
 			o.Logger = o.Logger.Level(logLevel)
 			return nil

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -133,7 +133,7 @@ func TestCommandLogLevelFlag(t *testing.T) {
 		{"error level", "error", false},
 		{"fatal level", "fatal", false},
 		{"panic level", "panic", false},
-		{"invalid level", "invalid", false},
+		{"invalid level", "invalid", true},
 	}
 
 	for _, tt := range tests {
@@ -147,7 +147,44 @@ func TestCommandLogLevelFlag(t *testing.T) {
 			cmd.SetErr(&output)
 			cmd.SetArgs([]string{"--log-level", tt.logLevel, "status"})
 
-			require.NoError(t, cmd.Execute())
+			err := cmd.Execute()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCommandLogLevelPropagatesToSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		want     log.Level
+	}{
+		{"trace level", "trace", log.TraceLevel},
+		{"debug level", "debug", log.DebugLevel},
+		{"warn level", "warn", log.WarnLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(log.ConsoleWriter{Out: os.Stderr})
+			ctx := context.Background()
+			opts := options.NewOptions(options.WithContext(ctx), options.WithLogger(logger))
+			cmd := NewCommand(opts)
+
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			// "wait" observably touches opts.Logger (via With().Str(...).Logger())
+			// before returning ErrNotRunning, without requiring a running daemon.
+			cmd.SetArgs([]string{"--log-level", tt.logLevel, "wait", "--timeout", "1ms"})
+
+			_ = cmd.Execute()
+
+			require.Equal(t, tt.want, opts.Logger.GetLevel())
 		})
 	}
 }
@@ -244,38 +281,4 @@ func TestCommandStructure(t *testing.T) {
 	require.Contains(t, subcommands, "status")
 	require.Contains(t, subcommands, "stop")
 	require.Contains(t, subcommands, "wait")
-}
-
-// Helper function to capture output
-func captureOutput(t *testing.T, fn func() error) (string, string, error) {
-	var stdout, stderr bytes.Buffer
-
-	// Save original
-	origStdout := os.Stdout
-	origStderr := os.Stderr
-
-	// Create pipes
-	r1, w1, _ := os.Pipe()
-	r2, w2, _ := os.Pipe()
-
-	// Set new outputs
-	os.Stdout = w1
-	os.Stderr = w2
-
-	// Execute function
-	err := fn()
-
-	// Close writers
-	w1.Close()
-	w2.Close()
-
-	// Read output
-	stdout.ReadFrom(r1)
-	stderr.ReadFrom(r2)
-
-	// Restore original
-	os.Stdout = origStdout
-	os.Stderr = origStderr
-
-	return stdout.String(), stderr.String(), err
 }

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
-	log "github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
 	"github.com/maxgio92/xcover/internal/settings"
@@ -90,18 +89,6 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	// Store PID file.
 	os.WriteFile(settings.PidFile, []byte(strconv.Itoa(os.Getpid())), 0644)
 	defer os.Remove(settings.PidFile)
-
-	var err error
-	o.LogLevel, err = cmd.Flags().GetString("log-level")
-	if err != nil {
-		return errors.Wrap(err, "failed to get log level")
-	}
-
-	logLevel, err := log.ParseLevel(o.LogLevel)
-	if err != nil {
-		o.Logger.Fatal().Err(err).Msg("invalid log level")
-	}
-	o.Logger = o.Logger.Level(logLevel)
 
 	scope, err := trace.ParseScope(o.scope)
 	if err != nil {

--- a/pkg/cmd/wait/wait.go
+++ b/pkg/cmd/wait/wait.go
@@ -10,7 +10,6 @@ import (
 	"github.com/maxgio92/xcover/pkg/cmd/common"
 	"github.com/maxgio92/xcover/pkg/cmd/options"
 	"github.com/maxgio92/xcover/pkg/healthcheck"
-	log "github.com/rs/zerolog"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -49,17 +48,7 @@ func NewCommand(opts *options.Options) *cobra.Command {
 }
 
 func (o *Options) Run(cmd *cobra.Command, _ []string) error {
-	var err error
-	o.LogLevel, err = cmd.Flags().GetString("log-level")
-	if err != nil {
-		return errors.Wrap(err, "failed to get log level")
-	}
-
-	logLevel, err := log.ParseLevel(o.LogLevel)
-	if err != nil {
-		o.Logger.Fatal().Err(err).Msg("invalid log level")
-	}
-	o.Logger = o.Logger.Level(logLevel).With().Str("component", "wait").Logger()
+	o.Logger = o.Logger.With().Str("component", "wait").Logger()
 
 	if !common.IsDaemonRunning() {
 		return ErrNotRunning


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 4 of 9).

`run.go` and `wait.go` each re-fetched and re-parsed `--log-level`, calling `Logger.Fatal()` on an invalid value, duplicating what `PersistentPreRunE` in `cmd.go` already does once for the whole command tree. Removes the duplication.

`PersistentPreRunE` now returns an error on an invalid level instead of logging and continuing with `NoLevel` (which previously suppressed all log output). This fails fast for every subcommand consistently, not just run and wait, and closes a real regression risk: without this, dropping run/wait's own Fatal check would have made an invalid `--log-level` silently mute all logging instead of failing.

Adds `TestCommandLogLevelPropagatesToSubcommand` asserting `--log-level` reaches the shared logger by the time a subcommand's `RunE` runs. Build, vet, and tests pass.