### PR TITLE
refactor: remove duplicated CoverageReport struct and path literals in e2e

### DIFF
--- a/e2e/project_scope_test.go
+++ b/e2e/project_scope_test.go
@@ -14,25 +14,25 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/maxgio92/xcover/internal/settings"
+	"github.com/maxgio92/xcover/pkg/coverage"
+	"github.com/maxgio92/xcover/pkg/trace"
 )
 
 const (
 	xcoverBinEnv           = "XCOVER_E2E_BIN"
-	pidFile                = "/tmp/xcover.pid"
-	socketFile             = "/tmp/xcover.sock"
-	logFile                = "/tmp/xcover.log"
 	reportFile             = "xcover-report.json"
 	projectScopeGoScenario = "project-scope-go-module"
 	projectScope           = "project"
 	binaryScope            = "binary"
 )
 
-type coverageReport struct {
-	FuncsTraced []string `json:"funcs_traced"`
-	FuncsAck    []string `json:"funcs_ack"`
-	CovByFunc   float64  `json:"cov_by_func"`
-	ExePath     string   `json:"exe_path"`
-}
+var (
+	pidFile    = settings.PidFile
+	socketFile = trace.HealthCheckSockPath
+	logFile    = settings.LogFile
+)
 
 func TestProjectScopeFiltersToGoModule(t *testing.T) {
 	report := runXcoverWithFixture(t, projectScope)
@@ -79,7 +79,7 @@ func TestBinaryScopeRetainsNonProjectSymbols(t *testing.T) {
 	}
 }
 
-func runXcoverWithFixture(t *testing.T, scope string) coverageReport {
+func runXcoverWithFixture(t *testing.T, scope string) coverage.CoverageReport {
 	t.Helper()
 
 	xcover := os.Getenv(xcoverBinEnv)
@@ -245,14 +245,14 @@ func shouldSkipForRuntimeEnvironment(output string) bool {
 		strings.Contains(output, "error initializing bpf probe")
 }
 
-func readReport(t *testing.T, path string) coverageReport {
+func readReport(t *testing.T, path string) coverage.CoverageReport {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read report %s: %v", path, err)
 	}
 
-	var report coverageReport
+	var report coverage.CoverageReport
 	if err := json.Unmarshal(data, &report); err != nil {
 		t.Fatalf("failed to parse report %s: %v", path, err)
 	}

--- a/e2e/project_scope_test.go
+++ b/e2e/project_scope_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/maxgio92/xcover/internal/settings"
 	"github.com/maxgio92/xcover/pkg/coverage"
-	"github.com/maxgio92/xcover/pkg/trace"
 )
 
 const (
@@ -30,7 +29,7 @@ const (
 
 var (
 	pidFile    = settings.PidFile
-	socketFile = trace.HealthCheckSockPath
+	socketFile = settings.HealthCheckSockPath
 	logFile    = settings.LogFile
 )
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -5,6 +5,7 @@ import "fmt"
 const CmdName = "xcover"
 
 var (
-	PidFile = fmt.Sprintf("/tmp/%s.pid", CmdName)
-	LogFile = fmt.Sprintf("/tmp/%s.log", CmdName)
+	PidFile             = fmt.Sprintf("/tmp/%s.pid", CmdName)
+	LogFile             = fmt.Sprintf("/tmp/%s.log", CmdName)
+	HealthCheckSockPath = fmt.Sprintf("/tmp/%s.sock", CmdName)
 )

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -22,12 +22,16 @@ const (
 	funNameLen                     = 64
 	bpfMaxBufferSize               = 1024                 // Maximum size of bpf_attr needed to batch offsets for uprobe_multi attachments.
 	bpfUprobeMultiAttachMaxOffsets = bpfMaxBufferSize / 8 // 8 is the byte size of uint64 used to represent offsets.
-	HealthCheckSockPath            = "/tmp/xcover.sock"
 )
 
 var (
 	feedChBufSize  = 4096
 	ReportFileName = fmt.Sprintf("%s-report.json", settings.CmdName)
+	// HealthCheckSockPath is kept as an alias of settings.HealthCheckSockPath
+	// for existing callers; internal/settings is the source of truth so
+	// cgo-free consumers (e.g. e2e tests) can reference it without pulling
+	// in this package's libbpf dependency.
+	HealthCheckSockPath = settings.HealthCheckSockPath
 )
 
 type FuncName struct {


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 5 of 9).

`e2e/project_scope_test.go` redeclared `pkg/coverage.CoverageReport` as a local `coverageReport` struct, and hardcoded `/tmp/xcover.pid`, `.sock`, `.log` as literals duplicating `internal/settings.PidFile`, `trace.HealthCheckSockPath`, and `internal/settings.LogFile`.

Turns out the original premise that e2e couldn't import `internal/` was wrong: `e2e` and `internal` are both directly under the module root, so Go's internal-visibility rule already permits the import (confirmed against `docs/docs.go`, which already imports `internal/settings`). No package move needed: this just imports the existing types/constants directly instead of duplicating them.

Build and vet pass, including `-tags e2e`.