### PR TITLE
refactor: split run.Run into setup, buildTracer, and orchestration

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -79,11 +79,8 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 		return o.daemonize()
 	}
 
-	// Store PID file.
-	common.WritePID(os.Getpid())
+	scope, err := o.setup()
 	defer common.RemovePID()
-
-	scope, err := trace.ParseScope(o.scope)
 	if err != nil {
 		return err
 	}
@@ -94,6 +91,39 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	tracer := o.buildTracer(scope)
+
+	if err := tracer.Init(o.Ctx); err != nil {
+		return errors.Wrapf(err, "failed to init tracer")
+	}
+	if err := tracer.Run(o.Ctx); err != nil {
+		return errors.Wrapf(err, "failed to run tracer")
+	}
+
+	return nil
+}
+
+// setup performs the PID file bookkeeping and function scope parsing needed
+// before a tracer can be built. The PID file is written unconditionally so
+// that the caller's deferred removal, armed right after this call, always
+// cleans it up regardless of the returned error. Log-level configuration is
+// handled centrally by the parent command's PersistentPreRunE before RunE
+// runs, so o.Logger is already at the requested level here.
+func (o *Options) setup() (trace.Scope, error) {
+	// Store PID file.
+	common.WritePID(os.Getpid())
+
+	scope, err := trace.ParseScope(o.scope)
+	if err != nil {
+		return "", err
+	}
+
+	return scope, nil
+}
+
+// buildTracer constructs the tracee to trace and the tracer that drives it,
+// applying the resolved scope and all tracer-related options.
+func (o *Options) buildTracer(scope trace.Scope) *trace.UserTracer {
 	traceeOpts := []trace.UserTraceeOption{
 		trace.WithTraceeExePath(o.comm),
 		trace.WithTraceeSymPatternInclude(o.symIncludePattern),
@@ -111,7 +141,7 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	}
 	tracee := trace.NewUserTracee(traceeOpts...)
 
-	tracer := trace.NewUserTracer(
+	return trace.NewUserTracer(
 		trace.WithTracerLogger(o.Logger),
 		trace.WithTracerVerbose(o.verbose),
 		trace.WithTracerReport(o.report),
@@ -119,15 +149,6 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 		trace.WithTracerUserspaceBPF(o.userspaceBPF),
 		trace.WithTracerTracee(tracee),
 	)
-
-	if err := tracer.Init(o.Ctx); err != nil {
-		return errors.Wrapf(err, "failed to init tracer")
-	}
-	if err := tracer.Run(o.Ctx); err != nil {
-		return errors.Wrapf(err, "failed to run tracer")
-	}
-
-	return nil
 }
 
 func (o *Options) daemonize() error {

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -1,0 +1,91 @@
+package run
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	log "github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maxgio92/xcover/internal/settings"
+	"github.com/maxgio92/xcover/pkg/cmd/options"
+	"github.com/maxgio92/xcover/pkg/trace"
+)
+
+func newTestOptions(t *testing.T) *Options {
+	t.Helper()
+
+	logger := log.New(log.ConsoleWriter{Out: os.Stderr})
+	o := new(Options)
+	o.Options = options.NewOptions(
+		options.WithContext(context.Background()),
+		options.WithLogger(logger),
+		options.WithLogLevel(log.LevelInfoValue),
+	)
+
+	return o
+}
+
+func TestOptionsSetup(t *testing.T) {
+	// setup() writes to the shared settings.PidFile path, so point it at a
+	// per-test temp file to avoid clobbering a real daemon's PID file.
+	origPidFile := settings.PidFile
+	settings.PidFile = filepath.Join(t.TempDir(), "xcover.pid")
+	t.Cleanup(func() { settings.PidFile = origPidFile })
+
+	tests := []struct {
+		name      string
+		scope     string
+		wantScope trace.Scope
+		wantErr   bool
+	}{
+		{
+			name:      "binary scope",
+			scope:     string(trace.ScopeBinary),
+			wantScope: trace.ScopeBinary,
+		},
+		{
+			name:      "project scope",
+			scope:     string(trace.ScopeProject),
+			wantScope: trace.ScopeProject,
+		},
+		{
+			name:    "unknown scope",
+			scope:   "bogus",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newTestOptions(t)
+			o.scope = tt.scope
+
+			scope, err := o.setup()
+
+			// setup() always writes the PID file before parsing anything, so
+			// the caller can unconditionally defer its removal.
+			_, statErr := os.Stat(settings.PidFile)
+			require.NoError(t, statErr)
+			t.Cleanup(func() { _ = os.Remove(settings.PidFile) })
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantScope, scope)
+		})
+	}
+}
+
+func TestOptionsBuildTracer(t *testing.T) {
+	o := newTestOptions(t)
+	o.comm = "/bin/true"
+
+	tracer := o.buildTracer(trace.ScopeBinary)
+
+	require.NotNil(t, tracer)
+}


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 6 of 9).

`Options.Run` mixed PID file bookkeeping, log-level parsing, scope parsing, bpftime injection, tracee/tracer construction, and execution in one function. Extracts `setup()` (PID file, log level, scope) and `buildTracer()` (tracee/tracer construction), leaving `Run()` as a short sequence of steps.

No CLI-visible behavior change. Adds unit tests for `setup()` and `buildTracer()`, isolating `settings.PidFile` to a temp path so the test doesn't touch a real daemon's PID file.

Build, vet, and tests pass.