### PR TITLE
refactor: forward daemon flags generically instead of hand-listing them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
@@ -21,7 +22,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.24.0 // indirect

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/maxgio92/xcover/internal/settings"
 	"github.com/maxgio92/xcover/pkg/bpftime"
@@ -69,14 +69,16 @@ It supports programs compiled to ELF.
 	cmd.Flags().StringVar(&o.scope, "scope", string(trace.ScopeBinary), `Function scope: "binary" (all functions) or "project" (project module only, Go binaries)`)
 	cmd.Flags().BoolVar(&o.userspaceBPF, "userspace-bpf", false, "Run BPF programs in userspace via bpftime (experimental)")
 
-	cmd.MarkFlagRequired("path")
+	if err := cmd.MarkFlagRequired("path"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }
 
 func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	if o.detach {
-		return o.daemonize()
+		return o.daemonize(cmd)
 	}
 
 	scope, err := o.setup()
@@ -151,34 +153,42 @@ func (o *Options) buildTracer(scope trace.Scope) *trace.UserTracer {
 	)
 }
 
-func (o *Options) daemonize() error {
+// daemonizeSkipFlags lists flags that must never be forwarded to the
+// re-exec'd daemon process, because they control the re-exec itself
+// (forwarding "detach" would make the daemon try to daemonize again).
+var daemonizeSkipFlags = map[string]bool{
+	"detach": true,
+}
+
+// forwardedFlagArgs walks the flags known to fs and returns the "--name=value"
+// arguments needed to reproduce every flag the user explicitly set, skipping
+// any flag named in skip. This lets a re-exec'd subprocess inherit whatever
+// flags the current invocation was given without the caller having to
+// hand-list every flag of the command.
+func forwardedFlagArgs(fs *pflag.FlagSet, skip map[string]bool) []string {
+	var args []string
+	fs.VisitAll(func(f *pflag.Flag) {
+		if !f.Changed || skip[f.Name] {
+			return
+		}
+		args = append(args, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
+	})
+
+	return args
+}
+
+func (o *Options) daemonize(cmd *cobra.Command) error {
 	// Check if already running.
 	if common.IsDaemonRunning() {
 		fmt.Println("Daemon already running")
 		return nil
 	}
 
-	// Start the daemon process.
-	args := []string{"run"}
-	args = append(args, fmt.Sprintf("--path=%s", o.comm))
-	args = append(args, fmt.Sprintf("--exclude=%s", o.symExcludePattern))
-	args = append(args, fmt.Sprintf("--include=%s", o.symIncludePattern))
-	args = append(args, fmt.Sprintf("--report=%s", strconv.FormatBool(o.report)))
-	args = append(args, fmt.Sprintf("--status=%s", strconv.FormatBool(o.status)))
-	args = append(args, fmt.Sprintf("--verbose=%s", strconv.FormatBool(o.verbose)))
-	args = append(args, fmt.Sprintf("--scope=%s", o.scope))
-	if o.debugPath != "" {
-		args = append(args, fmt.Sprintf("--debug-path=%s", o.debugPath))
-	}
-	if o.noBuildIDCheck {
-		args = append(args, "--no-build-id-check")
-	}
-	if o.userspaceBPF {
-		args = append(args, "--userspace-bpf")
-	}
+	// Start the daemon process, forwarding every flag the user set.
+	args := append([]string{"run"}, forwardedFlagArgs(cmd.Flags(), daemonizeSkipFlags)...)
 
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	daemonCmd := exec.Command(os.Args[0], args...)
+	daemonCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 	// Redirect output to log file.
 	if settings.LogFile != "" {
@@ -187,18 +197,18 @@ func (o *Options) daemonize() error {
 			o.Logger.Error().Err(err).Msg("failed to open log file")
 			return err
 		}
-		cmd.Stdout = f
-		cmd.Stderr = f
+		daemonCmd.Stdout = f
+		daemonCmd.Stderr = f
 	}
 
-	err := cmd.Start()
+	err := daemonCmd.Start()
 	if err != nil {
 		o.Logger.Error().Err(err).Msgf("failed to start %s", settings.CmdName)
 		return err
 	}
 
 	// Store PID file.
-	err = common.WritePID(cmd.Process.Pid)
+	err = common.WritePID(daemonCmd.Process.Pid)
 	if err != nil {
 		o.Logger.Error().Err(err).Msg("failed to write PID file")
 		return err

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	log "github.com/rs/zerolog"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
 	"github.com/maxgio92/xcover/internal/settings"
@@ -88,4 +89,80 @@ func TestOptionsBuildTracer(t *testing.T) {
 	tracer := o.buildTracer(trace.ScopeBinary)
 
 	require.NotNil(t, tracer)
+}
+
+func TestForwardedFlagArgs(t *testing.T) {
+	newFlagSet := func() *pflag.FlagSet {
+		fs := pflag.NewFlagSet("run", pflag.ContinueOnError)
+		fs.String("path", "", "")
+		fs.Int("pid", -1, "")
+		fs.String("exclude", "", "")
+		fs.String("include", "", "")
+		fs.String("debug-path", "", "")
+		fs.Bool("no-build-id-check", false, "")
+		fs.Bool("detach", false, "")
+		fs.Bool("verbose", false, "")
+		fs.Bool("report", true, "")
+		fs.Bool("status", true, "")
+		fs.String("scope", "binary", "")
+		fs.Bool("userspace-bpf", false, "")
+		fs.String("log-level", "info", "")
+
+		return fs
+	}
+
+	tests := []struct {
+		name string
+		set  func(fs *pflag.FlagSet)
+		want []string
+	}{
+		{
+			name: "only explicitly set flags are forwarded",
+			set: func(fs *pflag.FlagSet) {
+				require.NoError(t, fs.Set("path", "/bin/true"))
+			},
+			want: []string{"--path=/bin/true"},
+		},
+		{
+			name: "detach is never forwarded even when set",
+			set: func(fs *pflag.FlagSet) {
+				require.NoError(t, fs.Set("path", "/bin/true"))
+				require.NoError(t, fs.Set("detach", "true"))
+			},
+			want: []string{"--path=/bin/true"},
+		},
+		{
+			name: "boolean flags are forwarded as true/false",
+			set: func(fs *pflag.FlagSet) {
+				require.NoError(t, fs.Set("path", "/bin/true"))
+				require.NoError(t, fs.Set("report", "false"))
+				require.NoError(t, fs.Set("no-build-id-check", "true"))
+			},
+			want: []string{"--no-build-id-check=true", "--path=/bin/true", "--report=false"},
+		},
+		{
+			name: "pid and log-level are forwarded like any other flag",
+			set: func(fs *pflag.FlagSet) {
+				require.NoError(t, fs.Set("path", "/bin/true"))
+				require.NoError(t, fs.Set("pid", "1234"))
+				require.NoError(t, fs.Set("log-level", "debug"))
+			},
+			want: []string{"--log-level=debug", "--path=/bin/true", "--pid=1234"},
+		},
+		{
+			name: "unset flags are not forwarded",
+			set:  func(fs *pflag.FlagSet) {},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newFlagSet()
+			tt.set(fs)
+
+			got := forwardedFlagArgs(fs, daemonizeSkipFlags)
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 7 of 9).

`daemonize()` reconstructed the re-exec'd daemon's CLI args by manually listing each flag, so a new flag added to `run` silently wouldn't be forwarded. Replaces it with `forwardedFlagArgs()`, which walks `cmd.Flags()` and forwards every flag the user explicitly set (`Flag.Changed`), except `--detach`, which controls the re-exec itself.

**Behavior change:** `--pid` and `--log-level` are now forwarded to the daemon process; previously they were silently dropped. This looks like a pre-existing bug rather than an intended omission, since every other flag was already forwarded manually.

Adds `pflag` as a direct dependency (`go mod tidy`) since it's now imported directly for flag introspection. Adds unit tests for the new forwarding logic. Build, vet, and tests pass; sanity-checked `run --help` still registers all flags.