### PR TITLE
fix(probe): filter libbpf attach-failure warnings by content

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -129,6 +129,10 @@ func (p *Probe) Init(_ context.Context) error {
 // error already conveys, so it is downgraded to Debug. Any other warning
 // (e.g. malformed BPF object, missing kernel features) is left at Warn since
 // it is not otherwise surfaced and may be actionable.
+//
+// These substrings are coupled to libbpf's English log wording and may drift
+// across libbpf version bumps; re-check them against libbpf.c when updating
+// the vendored libbpf/libbpfgo version.
 var noisyAttachFailureSubstrings = []string{
 	"failed to attach multi-uprobe",              // bpf_link_create() for BPF_TRACE_UPROBE_MULTI
 	"failed to add legacy uprobe event",          // legacy uprobe: uprobe_events write

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/pkg/errors"
@@ -117,13 +118,47 @@ func (p *Probe) Init(_ context.Context) error {
 	return nil
 }
 
+// noisyAttachFailureSubstrings lists libbpf warning-level log fragments that
+// are emitted for uprobe/uprobe_multi attach failures we already surface as
+// wrapped Go errors (see Attach and attachSingleUprobes). The multi-uprobe
+// path logs one "failed to attach multi-uprobe" warning per bpf_link_create()
+// call for the whole batch, not per offset. The legacy uprobe path is taken
+// whenever the kernel lacks the modern perf uprobe PMU, and can also fire on
+// tracefs permission or mount issues unrelated to any specific offset. In
+// both cases the warning carries no information beyond what the caller-level
+// error already conveys, so it is downgraded to Debug. Any other warning
+// (e.g. malformed BPF object, missing kernel features) is left at Warn since
+// it is not otherwise surfaced and may be actionable.
+var noisyAttachFailureSubstrings = []string{
+	"failed to attach multi-uprobe",              // bpf_link_create() for BPF_TRACE_UPROBE_MULTI
+	"failed to add legacy uprobe event",          // legacy uprobe: uprobe_events write
+	"failed to determine legacy uprobe event id", // legacy uprobe: id lookup after registration
+	"legacy uprobe perf_event_open() failed",     // legacy uprobe: perf_event_open()
+}
+
+// isNoisyAttachFailure reports whether msg matches a known, already-reported
+// uprobe attach failure that should be downgraded to Debug rather than
+// surfaced at Warn.
+func isNoisyAttachFailure(msg string) bool {
+	for _, substr := range noisyAttachFailureSubstrings {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Probe) configureBPFLogger() {
 	bpf.SetLoggerCbs(bpf.Callbacks{
 		Log: func(level int, msg string) {
-			if level == bpf.LibbpfWarnLevel {
-				// TODO: filter for specific attach failures.
-				p.logger.Debug().Msgf("libbpf warning: %s", msg)
+			if level != bpf.LibbpfWarnLevel {
+				return
 			}
+			if isNoisyAttachFailure(msg) {
+				p.logger.Debug().Msgf("libbpf warning: %s", msg)
+				return
+			}
+			p.logger.Warn().Msgf("libbpf warning: %s", msg)
 		},
 	})
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -1,0 +1,50 @@
+package probe
+
+import "testing"
+
+func TestIsNoisyAttachFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "multi-uprobe attach failure",
+			msg:  "libbpf: prog 'handle_user_function': failed to attach multi-uprobe: Invalid argument",
+			want: true,
+		},
+		{
+			name: "legacy uprobe event registration failure",
+			msg:  "libbpf: failed to add legacy uprobe event for /bin/foo:0x1000: -2",
+			want: true,
+		},
+		{
+			name: "legacy uprobe event id lookup failure",
+			msg:  "libbpf: failed to determine legacy uprobe event id for /bin/foo:0x1000: -2",
+			want: true,
+		},
+		{
+			name: "legacy uprobe perf_event_open failure",
+			msg:  "libbpf: legacy uprobe perf_event_open() failed: -1",
+			want: true,
+		},
+		{
+			name: "unrelated warning is not filtered",
+			msg:  "libbpf: elf: failed to open /bin/foo as ELF file: invalid data",
+			want: false,
+		},
+		{
+			name: "empty message is not filtered",
+			msg:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoisyAttachFailure(tt.msg); got != tt.want {
+				t.Errorf("isNoisyAttachFailure(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of the refactoring tracking issue: #163 (PR 9 of 9).

`configureBPFLogger` downgraded every libbpf warning to Debug uniformly, defeating the point of the level check. The intent (per the TODO) was to silence already-surfaced attach failures while letting other warnings through at Warn. Adds `isNoisyAttachFailure` to match known uprobe attach-failure substrings (multi-uprobe and legacy uprobe paths, verified against libbpf 1.5.1 source) and only downgrades those.

**Behavior change:** warnings that previously were always downgraded to Debug (e.g. malformed BPF object, missing kernel features) now surface at Warn unless they match a known attach-failure pattern.

Adds unit tests for the filter predicate. Build, vet, and tests pass.