### PR TITLE
refactor: route status.go's PID read through common.ReadPID

### DIFF
--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,11 +30,11 @@ func NewCommand(opts *options.Options) *cobra.Command {
 
 func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	if common.IsDaemonRunning() {
-		pidData, err := os.ReadFile(settings.PidFile)
+		pid, err := common.ReadPID()
 		if err != nil {
 			return errors.Wrap(err, "failed to read PID file")
 		}
-		fmt.Printf("%s is running (PID %s)\n", settings.CmdName, pidData)
+		fmt.Printf("%s is running (PID %d)\n", settings.CmdName, pid)
 	} else {
 		fmt.Printf("%s is not running\n", settings.CmdName)
 	}


### PR DESCRIPTION
Follow-up to #163, addressing a non-blocking nit from dodoazzurro's review on #166: status.go was the one remaining site reading and parsing the PID file inline instead of through the shared helpers added for run.go and stop.go.

Uses `common.ReadPID` for consistency. The printed PID is now formatted as `%d` instead of the raw file bytes, equivalent since the file always contains just the PID as decimal digits.

Branched from main after #164, #165, and #166 merged, to avoid conflicting with either.

Build, vet, and tests pass; manually sanity-checked `status` output.