### PR TITLE
fix: honour --pid, fail on attach errors, and correct the coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
           file xcover
           ./xcover --help
 
+      - name: Verify generated docs are current
+        run: |
+          make docs
+          if [ -n "$(git status --porcelain README.md docs/)" ]; then
+            echo "README.md or docs/ are out of date. Run 'make docs' and commit the result."
+            git status --porcelain README.md docs/
+            git diff -- README.md docs/
+            exit 1
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ move the submodule to the same commit in the same PR.
 | Target | What it does |
 |---|---|
 | `make xcover` | Builds libbpf from the submodule, compiles the BPF object, builds the `xcover` binary. Use this first. |
-| `make xcover/bpf` | Compiles only `bpf/trace.bpf.c` into `pkg/probe/output/trace.bpf.o`. Generates `bpf/vmlinux.h` if missing. |
+| `make xcover/bpf` | Compiles only `bpf/trace.bpf.c` into `pkg/probe/output/trace.bpf.o`. Generates `bpf/vmlinux.h` if missing. Pass `CFLAGS=-DDEBUG` to compile in the `bpf_printk` calls, readable from `/sys/kernel/debug/tracing/trace_pipe`. |
 | `make xcover/frontend` | Builds only the Go binary. Needs the BPF object and libbpf already built, because the object is embedded with `go:embed`. |
 | `make xcover-userspace` | Clones and builds pinned bpftime, applies `patches/bpftime/*.patch`, embeds the two shared libraries and builds `xcover-userspace` with `-tags userspace`. |
 | `make bpftime-libs` | Only the bpftime step above. |
@@ -114,7 +114,8 @@ Hand-written pages such as `docs/xcover_userspace_bpf.md` and
 `docs/architecture.md` are not touched by the generator.
 
 The generator does not delete pages for removed commands; delete them by hand.
-CI does not yet check that generated docs are current.
+The `build` CI job runs `make docs` and fails when `README.md` or `docs/`
+differ from the committed files.
 
 ## Commit and pull request conventions
 

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,16 @@ OUTPUT := $(current_dir)/pkg/probe/output
 
 ARCH := $(subst x86_64,x86,$(shell uname -m))
 GOARCH := $(subst x86,amd64,$(subst aarch64,arm64,$(ARCH)))
+# libbpf's bpf_tracing.h checks __TARGET_ARCH_arm64, not the uname spelling.
+BPF_ARCH := $(subst aarch64,arm64,$(ARCH))
 
 # ebpf
 
 VMLINUXH := vmlinux.h
 BTFFILE := /sys/kernel/btf/vmlinux
 
-CFLAGS ?= -D__TARGET_ARCH_$(ARCH)
+# CFLAGS adds to the BPF compile, e.g. CFLAGS=-DDEBUG compiles in bpf_printk.
+BPF_CFLAGS := -D__TARGET_ARCH_$(BPF_ARCH) $(CFLAGS)
 
 # libbpf
 
@@ -95,7 +98,7 @@ docs:
 
 .PHONY: $(PROGRAM)/bpf
 $(PROGRAM)/bpf: $(OUTPUT) $(VMLINUXH)
-	clang $(CFLAGS) -g -O2 -c -target bpf \
+	clang $(BPF_CFLAGS) -g -O2 -c -target bpf \
 		-o $(OUTPUT)/trace.bpf.o bpf/trace.bpf.c
 
 .PHONY: $(foreach compile_mode,$(COMPILE_MODES),$(LIBBPFGO)-$(compile_mode))

--- a/README.md
+++ b/README.md
@@ -140,9 +140,16 @@ Non-Go binaries always use binary scope.
 
 ### Process filter
 
-`--pid` is accepted by the CLI but is not applied yet: probes attach to the
-executable file and fire for every process that runs it. Track progress in the
-issue tracker before relying on this flag.
+Probes attach to the executable file, so by default they fire for every
+process that runs it, including processes started after xcover. Pass `--pid`
+to record hits from one running process only:
+
+```shell
+xcover run --path EXE_PATH --pid 1234
+```
+
+The process must exist when xcover attaches, otherwise the attach fails and
+xcover exits. Hits from other processes of the same executable are ignored.
 
 ## Symbolization
 
@@ -194,7 +201,7 @@ written. State lives in fixed paths, so only one xcover daemon can run per host:
 | File | Purpose |
 |---|---|
 | `/tmp/xcover.pid` | PID of the running profiler. |
-| `/tmp/xcover.log` | stdout and stderr of the daemon. Warnings about scope fallback or failed attaches land here. |
+| `/tmp/xcover.log` | stdout and stderr of the daemon. Warnings about scope fallback and any attach error land here. |
 | `/tmp/xcover.sock` | Readiness socket used by `xcover wait`. |
 
 ```shell
@@ -229,11 +236,14 @@ type CoverageReport struct {
 Notes on the numbers:
 
 - Coverage is per function. There is no line, branch or call-count information.
-- Hits are aggregated across every process that ran the binary during the
-  session. The report does not say which process exercised a function.
-- A function whose probe failed to attach stays in `funcs_traced`, so a batch
-  attach failure lowers the reported coverage. Check `/tmp/xcover.log` for
-  warnings if the number looks too low.
+- By default hits are aggregated across every process that ran the binary
+  during the session, and the report does not say which process exercised a
+  function. Pass `--pid` to restrict tracing to one process.
+- An attach failure aborts the run before readiness is signalled and no report
+  is written, so a report always covers every function in `funcs_traced`.
+- Past 40960 distinct functions the kernel map is full and further functions
+  are not recorded; xcover warns on exit with the number of unrecorded calls.
+  See [Limitations](#limitations).
 
 Print the ratio with `jq .cov_by_func xcover-report.json`. Pass `--report=false`
 to skip the file.
@@ -265,11 +275,12 @@ latency benchmarks.
 - **First hit only, per session.** The kernel map dedups per function, so the
   report answers "did it run", not "how often".
 - **At most 40960 distinct functions per session.** Beyond that the kernel map
-  is full; further functions are neither recorded nor deduped, and every call
-  emits an event. Narrow the probe set with `--scope` or `--exclude`.
+  is full and the first hit of any further function is dropped, so the report
+  undercounts. xcover counts the unrecorded calls and warns on exit. Narrow the
+  probe set with `--scope` or `--exclude`.
 - **One daemon per host.** State files are fixed under `/tmp`.
-- **Kernel 6.6+, Linux only.** On older kernels the attach fails; xcover logs a
-  warning and reports 0% coverage rather than aborting.
+- **Kernel 6.6+, Linux only.** On older kernels the attach fails and xcover
+  exits with an error.
 - **Project scope is Go only** and falls back silently to binary scope for other
   binaries or single-file Go builds. Watch the log.
 - **Binary must not change on disk** while a session is running, because probe

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -140,9 +140,16 @@ Non-Go binaries always use binary scope.
 
 ### Process filter
 
-`--pid` is accepted by the CLI but is not applied yet: probes attach to the
-executable file and fire for every process that runs it. Track progress in the
-issue tracker before relying on this flag.
+Probes attach to the executable file, so by default they fire for every
+process that runs it, including processes started after xcover. Pass `--pid`
+to record hits from one running process only:
+
+```shell
+xcover run --path EXE_PATH --pid 1234
+```
+
+The process must exist when xcover attaches, otherwise the attach fails and
+xcover exits. Hits from other processes of the same executable are ignored.
 
 ## Symbolization
 
@@ -194,7 +201,7 @@ written. State lives in fixed paths, so only one xcover daemon can run per host:
 | File | Purpose |
 |---|---|
 | `/tmp/xcover.pid` | PID of the running profiler. |
-| `/tmp/xcover.log` | stdout and stderr of the daemon. Warnings about scope fallback or failed attaches land here. |
+| `/tmp/xcover.log` | stdout and stderr of the daemon. Warnings about scope fallback and any attach error land here. |
 | `/tmp/xcover.sock` | Readiness socket used by `xcover wait`. |
 
 ```shell
@@ -229,11 +236,14 @@ type CoverageReport struct {
 Notes on the numbers:
 
 - Coverage is per function. There is no line, branch or call-count information.
-- Hits are aggregated across every process that ran the binary during the
-  session. The report does not say which process exercised a function.
-- A function whose probe failed to attach stays in `funcs_traced`, so a batch
-  attach failure lowers the reported coverage. Check `/tmp/xcover.log` for
-  warnings if the number looks too low.
+- By default hits are aggregated across every process that ran the binary
+  during the session, and the report does not say which process exercised a
+  function. Pass `--pid` to restrict tracing to one process.
+- An attach failure aborts the run before readiness is signalled and no report
+  is written, so a report always covers every function in `funcs_traced`.
+- Past 40960 distinct functions the kernel map is full and further functions
+  are not recorded; xcover warns on exit with the number of unrecorded calls.
+  See [Limitations](#limitations).
 
 Print the ratio with `jq .cov_by_func xcover-report.json`. Pass `--report=false`
 to skip the file.
@@ -265,11 +275,12 @@ latency benchmarks.
 - **First hit only, per session.** The kernel map dedups per function, so the
   report answers "did it run", not "how often".
 - **At most 40960 distinct functions per session.** Beyond that the kernel map
-  is full; further functions are neither recorded nor deduped, and every call
-  emits an event. Narrow the probe set with `--scope` or `--exclude`.
+  is full and the first hit of any further function is dropped, so the report
+  undercounts. xcover counts the unrecorded calls and warns on exit. Narrow the
+  probe set with `--scope` or `--exclude`.
 - **One daemon per host.** State files are fixed under `/tmp`.
-- **Kernel 6.6+, Linux only.** On older kernels the attach fails; xcover logs a
-  warning and reports 0% coverage rather than aborting.
+- **Kernel 6.6+, Linux only.** On older kernels the attach fails and xcover
+  exits with an error.
 - **Project scope is Go only** and falls back silently to binary scope for other
   binaries or single-file Go builds. Watch the log.
 - **Binary must not change on disk** while a session is running, because probe

--- a/bpf/trace.bpf.c
+++ b/bpf/trace.bpf.c
@@ -3,6 +3,14 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 
+/* Trace-pipe logging costs a few hundred ns per call, so it is compiled in
+ * only with -DDEBUG (make xcover/bpf CFLAGS=-DDEBUG). */
+#ifdef DEBUG
+#define dbg_printk(fmt, ...) bpf_printk(fmt, ##__VA_ARGS__)
+#else
+#define dbg_printk(fmt, ...) do {} while (0)
+#endif
+
 /* Function trace event */
 struct event_t {
     __u64 cookie; /* Cookie is a function identifier */
@@ -22,6 +30,15 @@ struct {
     __type(value, u8);          /* Report marker */
 } seen_funcs SEC(".maps");
 
+/* Calls not recorded because seen_funcs was full, one per call. Userspace
+ * reads it on exit to warn that the report undercounts. */
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, u64);
+} drops SEC(".maps");
+
 long ringbuffer_flags = 0;
 
 SEC("uprobe/handle_user_function")
@@ -29,28 +46,38 @@ int handle_user_function(struct pt_regs *ctx) {
 	__u64 cookie = bpf_get_attach_cookie(ctx);
 	u8 seen = 1;
 
-	bpf_printk("handle user function with cookie %llu\n", cookie);
+	dbg_printk("handle user function with cookie %llu\n", cookie);
 
 	/* Check if the function has been already reported */
 	if (bpf_map_lookup_elem(&seen_funcs, &cookie)) {
-		bpf_printk("function with cookie %llu already reported, skipping\n", cookie);
+		dbg_printk("function with cookie %llu already reported, skipping\n", cookie);
 
 		return 0;
 	}
 
-	/* Track which functions have been reported */
-	bpf_map_update_elem(&seen_funcs, &cookie, &seen, BPF_ANY);
+	/* Track which functions have been reported. When the map is full the
+	 * function cannot be deduplicated, so count the drop instead of flooding
+	 * the ring buffer with one event per call. */
+	if (bpf_map_update_elem(&seen_funcs, &cookie, &seen, BPF_ANY) < 0) {
+		u32 zero = 0;
+		u64 *dropped = bpf_map_lookup_elem(&drops, &zero);
+		if (dropped)
+			__sync_fetch_and_add(dropped, 1);
+		dbg_printk("seen_funcs full, dropping first hit for cookie %llu\n", cookie);
+
+		return 0;
+	}
 
 	struct event_t *event = bpf_ringbuf_reserve(&events, sizeof(struct event_t), 0);
 	if (!event) {
-		bpf_printk("error submitting event to ring buffer for user function with cookie %llu\n", cookie);
+		dbg_printk("error submitting event to ring buffer for user function with cookie %llu\n", cookie);
 
 		return 0;
 	}
 
 	event->cookie = cookie;
 	bpf_ringbuf_submit(event, ringbuffer_flags);
-	bpf_printk("submitted event to ring buffer for user function with cookie %llu\n", cookie);
+	dbg_printk("submitted event to ring buffer for user function with cookie %llu\n", cookie);
 
 	return 0;
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,8 @@ uprobes are addressed by file offset, PIE and ASLR need no special handling.
 `shouldInclude` in `resolver.go` applies, in order: symbol binding exclude,
 symbol binding include (library API only), `--exclude` regex, `--include`
 regex. Exclude wins over include. Project scope filtering runs after these.
+The regexes are compiled once when the resolver is built; an invalid pattern
+is returned as an error from the first resolver call.
 
 Functions are stored in a map keyed by file offset. The offset is also the BPF
 cookie, so two names at the same address (weak aliases, identical code folding)
@@ -85,9 +87,10 @@ since 5.11), and sets the expected attach type to `TRACE_UPROBE_MULTI`.
 
 `UserTracer.attachProbe` in `tracer.go` splits offsets into batches of 128, the
 largest that fits the kernel's `bpf_attr` buffer, and calls
-`AttachUprobeMulti(-1, exePath, offsets, cookies)` per batch. The PID argument
-`-1` means every process that maps the file. A failed batch is logged as a
-warning and skipped; the tracer still reports readiness.
+`AttachUprobeMulti(pid, exePath, offsets, cookies)` per batch. The PID
+argument comes from `--pid`; the default `-1` (`probe.PIDAll`) means every
+process that maps the file. A failed batch aborts `Run` with an error before
+readiness is signalled, and the links already attached are destroyed.
 
 In userspace BPF mode bpftime does not implement `uprobe_multi`, so
 `attachSingleUprobes` attaches one perf-event uprobe per function instead.
@@ -102,10 +105,13 @@ The socket is removed on every exit path.
 ### 6. Events
 
 `bpf/trace.bpf.c` defines two maps: `events`, a 256 MB ring buffer, and
-`seen_funcs`, a hash map of 40960 cookies. The program reads the attach cookie,
-returns if the cookie is already in `seen_funcs`, otherwise inserts it and
-submits an 8-byte event. The program only fires on function entry; there is no
-return probe.
+`seen_funcs`, a hash map of 40960 cookies, plus `drops`, a one-element array
+counter. The program reads the attach cookie, returns if the cookie is already
+in `seen_funcs`, otherwise inserts it and submits an 8-byte event. If the
+insert fails because the map is full, the program increments `drops` and
+submits nothing; the tracer reads the counter on exit and warns when it is
+non-zero. `bpf_printk` tracing is compiled in only with `CFLAGS=-DDEBUG`. The
+program only fires on function entry; there is no return probe.
 
 Userspace polls the ring buffer every 60 ms into a channel of 4096 events, a
 second goroutine forwards them, and `handleEvent` decodes the cookie and stores
@@ -116,8 +122,10 @@ it in the `ack` map.
 On `SIGINT` or `SIGTERM` the tracer drains its goroutines, destroys the links
 (which detaches the probes) and writes `xcover-report.json` in the current
 directory when `--report` is true. `funcs_traced` is every resolved function,
-`funcs_ack` the names found for acknowledged cookies, `cov_by_func` the ratio
-of acknowledged cookies to resolved functions times 100.
+`funcs_ack` the names found for acknowledged cookies, `cov_by_func` is
+`len(funcs_ack) / len(funcs_traced) * 100`. A cookie that resolves to no
+function is skipped. A report file that cannot be created is returned as an
+error.
 
 ## Daemon mode
 
@@ -143,17 +151,4 @@ temporary file and prints the path. See
 These are visible from reading the code and worth knowing before you change the
 related areas:
 
-- `--pid` is parsed into `Options.pid` but never used; attach always passes
-  `-1`.
-- `Probe.Attach` returns `nil` after a failed `uprobe_multi` attach, so partial
-  instrumentation is silent apart from a warning.
-- In `writeReport`, the `ack.Range` callback returns `false` on a cookie it
-  cannot resolve, which stops the iteration and truncates `funcs_ack`.
-  `cov_by_func` uses the raw ack count, so it can disagree with
-  `len(funcs_ack)`. See issue #175.
-- `bpf/trace.bpf.c` calls `bpf_printk` on every hit, including the fast path.
-- `bpf_map_update_elem` on `seen_funcs` is not checked; past 40960 entries every
-  call of an untracked function emits an event.
-- `shouldInclude` compiles the include and exclude regexes once per symbol, and
-  an invalid pattern panics instead of returning an error.
 - `internal/utils.Hash` and `pkg/static` are unused by the CLI path.

--- a/docs/xcover_run.md
+++ b/docs/xcover_run.md
@@ -23,7 +23,7 @@ xcover run [flags]
       --include string      Regex pattern to include function symbol names
       --no-build-id-check   Skip GNU build-id verification between --path and --debug-path
   -p, --path string         Path to the ELF executable
-      --pid int             Filter the process by PID (default -1)
+      --pid int             Only trace the process with this PID; -1 traces every process running the executable (default -1)
       --report              Generate report (as xcover-report.json) (default true)
       --scope string        Function scope: "binary" (all functions) or "project" (project module only, Go binaries) (default "binary")
       --status              Periodically print a status of the trace (default true)

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 	"github.com/maxgio92/xcover/pkg/bpftime"
 	"github.com/maxgio92/xcover/pkg/cmd/common"
 	"github.com/maxgio92/xcover/pkg/cmd/options"
+	"github.com/maxgio92/xcover/pkg/probe"
 	"github.com/maxgio92/xcover/pkg/trace"
 )
 
@@ -54,7 +56,7 @@ It supports programs compiled to ELF.
 	}
 
 	cmd.Flags().StringVarP(&o.comm, "path", "p", "", "Path to the ELF executable")
-	cmd.Flags().IntVar(&o.pid, "pid", -1, "Filter the process by PID")
+	cmd.Flags().IntVar(&o.pid, "pid", probe.PIDAll, "Only trace the process with this PID; -1 traces every process running the executable")
 
 	cmd.Flags().StringVar(&o.symExcludePattern, "exclude", "", "Regex pattern to exclude function symbol names")
 	cmd.Flags().StringVar(&o.symIncludePattern, "include", "", "Regex pattern to include function symbol names")
@@ -105,7 +107,7 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// setup performs the PID file bookkeeping and function scope parsing needed
+// setup performs the PID file bookkeeping and validates the flags needed
 // before a tracer can be built. The PID file is written unconditionally so
 // that the caller's deferred removal, armed right after this call, always
 // cleans it up regardless of the returned error. Log-level configuration is
@@ -114,6 +116,14 @@ func (o *Options) Run(cmd *cobra.Command, _ []string) error {
 func (o *Options) setup() (trace.Scope, error) {
 	// Store PID file.
 	common.WritePID(os.Getpid())
+
+	// libbpf maps pid 0 to xcover's own process and treats every negative
+	// value as "all processes", so anything other than a real PID or PIDAll
+	// would silently trace the wrong set of processes. libbpfgo converts the
+	// value to a C int, so anything above MaxInt32 would wrap the same way.
+	if o.pid == 0 || o.pid < probe.PIDAll || o.pid > math.MaxInt32 {
+		return "", fmt.Errorf("--pid must be a positive PID up to %d or %d, got %d", math.MaxInt32, probe.PIDAll, o.pid)
+	}
 
 	scope, err := trace.ParseScope(o.scope)
 	if err != nil {
@@ -145,6 +155,7 @@ func (o *Options) buildTracer(scope trace.Scope) *trace.UserTracer {
 
 	return trace.NewUserTracer(
 		trace.WithTracerLogger(o.Logger),
+		trace.WithTracerPID(o.pid),
 		trace.WithTracerVerbose(o.verbose),
 		trace.WithTracerReport(o.report),
 		trace.WithTracerStatus(o.status),

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/maxgio92/xcover/internal/settings"
 	"github.com/maxgio92/xcover/pkg/cmd/options"
+	"github.com/maxgio92/xcover/pkg/probe"
 	"github.com/maxgio92/xcover/pkg/trace"
 )
 
@@ -39,22 +41,63 @@ func TestOptionsSetup(t *testing.T) {
 	tests := []struct {
 		name      string
 		scope     string
+		pid       int
 		wantScope trace.Scope
 		wantErr   bool
 	}{
 		{
 			name:      "binary scope",
 			scope:     string(trace.ScopeBinary),
+			pid:       probe.PIDAll,
 			wantScope: trace.ScopeBinary,
 		},
 		{
 			name:      "project scope",
 			scope:     string(trace.ScopeProject),
+			pid:       probe.PIDAll,
 			wantScope: trace.ScopeProject,
 		},
 		{
 			name:    "unknown scope",
 			scope:   "bogus",
+			pid:     probe.PIDAll,
+			wantErr: true,
+		},
+		{
+			name:      "positive pid",
+			scope:     string(trace.ScopeBinary),
+			pid:       os.Getpid(),
+			wantScope: trace.ScopeBinary,
+		},
+		{
+			// libbpf resolves pid 0 to xcover's own process, which never maps
+			// the traced executable, so it must be rejected instead of
+			// producing an empty report.
+			name:    "zero pid",
+			scope:   string(trace.ScopeBinary),
+			pid:     0,
+			wantErr: true,
+		},
+		{
+			// libbpf treats every negative pid as "all processes"; only
+			// PIDAll is documented, so other negatives are rejected.
+			name:    "negative pid other than PIDAll",
+			scope:   string(trace.ScopeBinary),
+			pid:     -7,
+			wantErr: true,
+		},
+		{
+			name:      "largest C int pid",
+			scope:     string(trace.ScopeBinary),
+			pid:       math.MaxInt32,
+			wantScope: trace.ScopeBinary,
+		},
+		{
+			// libbpfgo narrows the pid to a C int, so 4294967295 would wrap
+			// to -1 and silently trace every process.
+			name:    "pid above MaxInt32",
+			scope:   string(trace.ScopeBinary),
+			pid:     math.MaxInt32 + 1,
 			wantErr: true,
 		},
 	}
@@ -63,6 +106,7 @@ func TestOptionsSetup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			o := newTestOptions(t)
 			o.scope = tt.scope
+			o.pid = tt.pid
 
 			scope, err := o.setup()
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -3,9 +3,11 @@ package probe
 import (
 	"context"
 	"embed"
+	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/pkg/errors"
@@ -22,6 +24,11 @@ const (
 	EventsChBufSize       = 4096
 	evtRingBufBPFMapName  = "events"
 	evtRingBufPollTimeout = 60
+	dropsBPFMapName       = "drops"
+
+	// PIDAll attaches the probes to every process running the executable,
+	// following libbpf's convention where a negative pid disables the filter.
+	PIDAll = -1
 )
 
 type Probe struct {
@@ -34,6 +41,8 @@ type Probe struct {
 
 	EvtBuf *bpf.RingBuffer
 
+	// pid restricts the uprobes to one process; PIDAll traces every process.
+	pid          int
 	userspaceBPF bool
 
 	logger log.Logger
@@ -57,8 +66,17 @@ func WithUserspaceBPF() Option {
 	}
 }
 
+// WithPID restricts the uprobes to the process with the given PID. The
+// process must exist at attach time. PIDAll (the default) traces every
+// process that runs the executable.
+func WithPID(pid int) Option {
+	return func(p *Probe) {
+		p.pid = pid
+	}
+}
+
 func NewProbe(opts ...Option) *Probe {
-	p := new(Probe)
+	p := &Probe{pid: PIDAll}
 	for _, opt := range opts {
 		opt(p)
 	}
@@ -172,13 +190,31 @@ func (p *Probe) Attach(_ context.Context, exePath string, offsets, cookies []uin
 		return p.attachSingleUprobes(exePath, offsets, cookies)
 	}
 
-	link, err := p.bpfProg.AttachUprobeMulti(-1, exePath, offsets, cookies)
+	link, err := p.bpfProg.AttachUprobeMulti(p.pid, exePath, offsets, cookies)
 	if err != nil {
-		p.logger.Warn().Err(errors.Wrapf(err, "error attaching uprobe for functions with cookies: %v", cookies))
-		return nil
+		return errors.Wrapf(err, "attach uprobe_multi for functions with cookies %v", cookies)
 	}
 	p.links = append(p.links, link)
 	return nil
+}
+
+// Drops returns how many calls the BPF program could not record because the
+// seen_funcs map was full. The counter increments on every such call, so it
+// is an upper bound on the number of functions missing from the report.
+func (p *Probe) Drops() (uint64, error) {
+	m, err := p.bpfMod.GetMap(dropsBPFMapName)
+	if err != nil {
+		return 0, err
+	}
+	key := uint32(0)
+	val, err := m.GetValue(unsafe.Pointer(&key))
+	if err != nil {
+		return 0, errors.Wrapf(err, "lookup map %s", dropsBPFMapName)
+	}
+	if len(val) < 8 {
+		return 0, fmt.Errorf("map %s: value size %d, want 8", dropsBPFMapName, len(val))
+	}
+	return binary.NativeEndian.Uint64(val), nil
 }
 
 func (p *Probe) InitEventBuf(ctx context.Context) (chan []byte, error) {
@@ -234,7 +270,7 @@ func (p *Probe) CloseBPFMod() {
 func (p *Probe) attachSingleUprobes(exePath string, offsets, cookies []uint64) error {
 	for i, offset := range offsets {
 		cookie := cookies[i]
-		link, err := p.bpfProg.AttachUprobeWithOpts(-1, exePath, offset, cookie)
+		link, err := p.bpfProg.AttachUprobeWithOpts(p.pid, exePath, offset, cookie)
 		if err != nil {
 			return fmt.Errorf("attach uprobe at offset 0x%x cookie 0x%x: %w", offset, cookie, err)
 		}

--- a/pkg/trace/resolver.go
+++ b/pkg/trace/resolver.go
@@ -27,7 +27,11 @@ type FunctionResolver func(ctx context.Context) ([]FunctionEntry, error)
 // with a .gopclntab fallback for stripped Go binaries.
 // path is the binary to open; the resolver opens and closes it itself.
 func SymbolTableResolver(path string, logger log.Logger, include, exclude string, bindInclude, bindExclude []elf.SymBind) FunctionResolver {
+	incRe, excRe, patternErr := compileSymPatterns(include, exclude)
 	return func(ctx context.Context) ([]FunctionEntry, error) {
+		if patternErr != nil {
+			return nil, patternErr
+		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -42,11 +46,11 @@ func SymbolTableResolver(path string, logger log.Logger, include, exclude string
 			return nil, err
 		}
 
-		syms, err := funcSymsFromELF(f, include, exclude, bindInclude, bindExclude)
+		syms, err := funcSymsFromELF(f, incRe, excRe, bindInclude, bindExclude)
 		if err != nil {
 			if errors.Is(err, elf.ErrNoSymbols) {
 				logger.Info().Msg("binary is stripped, attempting .gopclntab fallback")
-				entries, err := funcEntriesFromGoPclntab(f, include, exclude, bindInclude, bindExclude, logger)
+				entries, err := funcEntriesFromGoPclntab(f, incRe, excRe, bindInclude, bindExclude, logger)
 				if err != nil {
 					return nil, errors.Wrap(ErrNoSymbolTable, err.Error())
 				}
@@ -56,7 +60,7 @@ func SymbolTableResolver(path string, logger log.Logger, include, exclude string
 		}
 		if len(syms) == 0 {
 			logger.Info().Msg("no function symbols found, attempting .gopclntab fallback")
-			entries, goPclnErr := funcEntriesFromGoPclntab(f, include, exclude, bindInclude, bindExclude, logger)
+			entries, goPclnErr := funcEntriesFromGoPclntab(f, incRe, excRe, bindInclude, bindExclude, logger)
 			if goPclnErr != nil {
 				return nil, ErrNoFunctionSymbols
 			}
@@ -69,8 +73,24 @@ func SymbolTableResolver(path string, logger log.Logger, include, exclude string
 	}
 }
 
+// compileSymPatterns compiles the --include and --exclude patterns once per
+// resolver. An empty pattern yields a nil *regexp.Regexp, meaning no filter.
+func compileSymPatterns(include, exclude string) (incRe, excRe *regexp.Regexp, err error) {
+	if include != "" {
+		if incRe, err = regexp.Compile(include); err != nil {
+			return nil, nil, errors.Wrap(err, "invalid include pattern")
+		}
+	}
+	if exclude != "" {
+		if excRe, err = regexp.Compile(exclude); err != nil {
+			return nil, nil, errors.Wrap(err, "invalid exclude pattern")
+		}
+	}
+	return incRe, excRe, nil
+}
+
 // funcSymsFromELF returns filtered function symbols from the ELF symbol table.
-func funcSymsFromELF(f *elf.File, include, exclude string, bindInclude, bindExclude []elf.SymBind) ([]elf.Symbol, error) {
+func funcSymsFromELF(f *elf.File, include, exclude *regexp.Regexp, bindInclude, bindExclude []elf.SymBind) ([]elf.Symbol, error) {
 	syms, err := f.Symbols()
 	if err != nil {
 		return nil, err
@@ -109,7 +129,7 @@ func funcEntriesFromSymbols(syms []elf.Symbol, toOffset func(uint64) (uint64, er
 
 // funcEntriesFromGoPclntab extracts function entries from the .gopclntab section,
 // which is retained even in stripped Go binaries.
-func funcEntriesFromGoPclntab(f *elf.File, include, exclude string, bindInclude, bindExclude []elf.SymBind, logger log.Logger) ([]FunctionEntry, error) {
+func funcEntriesFromGoPclntab(f *elf.File, include, exclude *regexp.Regexp, bindInclude, bindExclude []elf.SymBind, logger log.Logger) ([]FunctionEntry, error) {
 	pclntabSection := f.Section(".gopclntab")
 	if pclntabSection == nil {
 		return nil, errors.New("no .gopclntab section found - not a Go binary or section stripped")
@@ -173,8 +193,9 @@ func vaToFileOffset(f *elf.File, va uint64) (uint64, error) {
 	return 0, fmt.Errorf("VA 0x%x not covered by any loadable segment", va)
 }
 
-// shouldInclude reports whether sym passes the include/exclude filters.
-func shouldInclude(sym elf.Symbol, include, exclude string, bindInclude, bindExclude []elf.SymBind) bool {
+// shouldInclude reports whether sym passes the include/exclude filters. A nil
+// include or exclude regex means that filter is not set.
+func shouldInclude(sym elf.Symbol, include, exclude *regexp.Regexp, bindInclude, bindExclude []elf.SymBind) bool {
 	if bindExclude != nil {
 		for _, b := range bindExclude {
 			if elf.ST_BIND(sym.Info) == b {
@@ -190,11 +211,11 @@ func shouldInclude(sym elf.Symbol, include, exclude string, bindInclude, bindExc
 		}
 		return false
 	}
-	if exclude != "" && regexp.MustCompile(exclude).MatchString(sym.Name) {
+	if exclude != nil && exclude.MatchString(sym.Name) {
 		return false
 	}
-	if include != "" {
-		return regexp.MustCompile(include).MatchString(sym.Name)
+	if include != nil {
+		return include.MatchString(sym.Name)
 	}
 	return true
 }

--- a/pkg/trace/resolver_debug.go
+++ b/pkg/trace/resolver_debug.go
@@ -6,6 +6,7 @@ import (
 	"debug/dwarf"
 	"debug/elf"
 	"encoding/binary"
+	"regexp"
 
 	"github.com/pkg/errors"
 	log "github.com/rs/zerolog"
@@ -35,7 +36,11 @@ const ntGNUBuildID = 3
 // recovery: when the user explicitly supplies a debug file, a problem with it
 // should be reported, not papered over with synthetic func_0x<addr> names.
 func SeparateDebugResolver(exePath, debugPath string, logger log.Logger, include, exclude string, bindInclude, bindExclude []elf.SymBind, skipBuildID bool) FunctionResolver {
+	incRe, excRe, patternErr := compileSymPatterns(include, exclude)
 	return func(ctx context.Context) ([]FunctionEntry, error) {
+		if patternErr != nil {
+			return nil, patternErr
+		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -66,7 +71,7 @@ func SeparateDebugResolver(exePath, debugPath string, logger log.Logger, include
 
 		// Primary: the debug file's .symtab (retained by --only-keep-debug and
 		// `eu-strip -f`). Names here are already linkage-level and unambiguous.
-		syms, err := funcSymsFromELF(dbg, include, exclude, bindInclude, bindExclude)
+		syms, err := funcSymsFromELF(dbg, incRe, excRe, bindInclude, bindExclude)
 		if err == nil {
 			if syms = definedFuncs(syms); len(syms) > 0 {
 				logger.Info().Int("symbols", len(syms)).Msg("resolved functions from debug file .symtab")
@@ -76,7 +81,7 @@ func SeparateDebugResolver(exePath, debugPath string, logger log.Logger, include
 
 		// Fallback: DWARF subprograms. Best-effort — see funcSymsFromDWARF.
 		logger.Info().Msg("debug file has no usable .symtab; trying DWARF subprograms")
-		dwarfSyms, derr := funcSymsFromDWARF(dbg, include, exclude, logger)
+		dwarfSyms, derr := funcSymsFromDWARF(dbg, incRe, excRe, logger)
 		if derr != nil {
 			return nil, errors.Wrapf(derr, "no usable symbols in debug file %q (.symtab and DWARF both failed)", debugPath)
 		}
@@ -134,7 +139,7 @@ type dwarfSubprogram struct {
 //     these forms to raw offsets but never loads the supplementary file, so
 //     such names resolve empty and are skipped. Common on Fedora/Debian
 //     debuginfod, which dwz-process their debug files.
-func funcSymsFromDWARF(f *elf.File, include, exclude string, logger log.Logger) ([]elf.Symbol, error) {
+func funcSymsFromDWARF(f *elf.File, include, exclude *regexp.Regexp, logger log.Logger) ([]elf.Symbol, error) {
 	d, err := f.DWARF()
 	if err != nil {
 		return nil, errors.Wrap(err, "no DWARF info")

--- a/pkg/trace/resolver_test.go
+++ b/pkg/trace/resolver_test.go
@@ -42,3 +42,15 @@ func TestWithTraceeResolver_CustomResolver(t *testing.T) {
 	assert.Contains(t, offsets, uint64(0x1000))
 	assert.Contains(t, offsets, uint64(0x2000))
 }
+
+// TestSymbolTableResolver_InvalidPattern verifies that a malformed --include
+// or --exclude regex is reported as an error from the resolver instead of
+// panicking while symbols are filtered. The pattern is checked before the
+// binary is opened, so no real file is needed.
+func TestSymbolTableResolver_InvalidPattern(t *testing.T) {
+	_, err := trace.SymbolTableResolver("dummy-path", testLogger, "(", "", nil, nil)(t.Context())
+	require.ErrorContains(t, err, "invalid include pattern")
+
+	_, err = trace.SeparateDebugResolver("dummy-path", "dummy-debug", testLogger, "", "[", nil, nil, true)(t.Context())
+	require.ErrorContains(t, err, "invalid exclude pattern")
+}

--- a/pkg/trace/should_include_test.go
+++ b/pkg/trace/should_include_test.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"debug/elf"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,12 +13,30 @@ func TestShouldInclude(t *testing.T) {
 		Name: "main.fooFunction",
 		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
 	}
-	require.True(t, shouldInclude(fooSym, "^main.fooFunction$", "", nil, nil))
+	require.True(t, shouldInclude(fooSym, regexp.MustCompile("^main.fooFunction$"), nil, nil, nil))
 
 	runtimeSym := elf.Symbol{
 		Name: "runtime.sched",
 		Info: elf.ST_INFO(elf.STB_GLOBAL, elf.STT_FUNC),
 	}
-	require.True(t, shouldInclude(runtimeSym, "", "", nil, nil))
-	require.False(t, shouldInclude(runtimeSym, "", "^runtime.", nil, nil))
+	require.True(t, shouldInclude(runtimeSym, nil, nil, nil, nil))
+	require.False(t, shouldInclude(runtimeSym, nil, regexp.MustCompile("^runtime."), nil, nil))
+}
+
+func TestCompileSymPatterns(t *testing.T) {
+	inc, exc, err := compileSymPatterns("", "")
+	require.NoError(t, err)
+	require.Nil(t, inc)
+	require.Nil(t, exc)
+
+	inc, exc, err = compileSymPatterns("^main", "^runtime")
+	require.NoError(t, err)
+	require.True(t, inc.MatchString("main.foo"))
+	require.True(t, exc.MatchString("runtime.sched"))
+
+	_, _, err = compileSymPatterns("(", "")
+	require.ErrorContains(t, err, "invalid include pattern")
+
+	_, _, err = compileSymPatterns("", "(")
+	require.ErrorContains(t, err, "invalid exclude pattern")
 }

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -54,7 +54,7 @@ type UserTracer struct {
 
 func NewUserTracer(opts ...UserTracerOpt) *UserTracer {
 	tracer := &UserTracer{
-		UserTracerOptions: &UserTracerOptions{},
+		UserTracerOptions: &UserTracerOptions{pid: probe.PIDAll},
 	}
 	for _, opt := range opts {
 		opt(tracer)
@@ -94,7 +94,7 @@ func (t *UserTracer) Init(ctx context.Context) error {
 		return err
 	}
 
-	probeOpts := []probe.Option{probe.WithLogger(t.logger)}
+	probeOpts := []probe.Option{probe.WithLogger(t.logger), probe.WithPID(t.pid)}
 	if t.userspaceBPF {
 		probeOpts = append(probeOpts, probe.WithUserspaceBPF())
 	}
@@ -124,14 +124,18 @@ func (t *UserTracer) Run(ctx context.Context) error {
 		}
 	}()
 
-	// Attach one uprobe per function to trace.
-	t.logger.Debug().Msg("attaching trace to selected functions")
-	t.attachProbe(ctx)
 	// Defers run LIFO: CloseBPFMod must be registered before CloseEventBuf so
 	// it runs second, after CloseEventBuf stops the ring buffer poll goroutine.
-	// Registering it right after attach also detaches the uprobes when
-	// InitEventBuf fails.
+	// Registering it before attach also detaches the links of a partially
+	// attached batch set when a later batch or InitEventBuf fails.
 	defer t.probe.CloseBPFMod()
+
+	// Attach one uprobe per function to trace. Abort before signalling
+	// readiness: a partially probed binary would report a misleading ratio.
+	t.logger.Debug().Msg("attaching trace to selected functions")
+	if err := t.attachProbe(ctx); err != nil {
+		return errors.Wrap(err, "error attaching probes")
+	}
 
 	eventsCh, err := t.probe.InitEventBuf(ctx)
 	if err != nil {
@@ -196,10 +200,27 @@ func (t *UserTracer) waitAndReport(ctx context.Context, wg *sync.WaitGroup) erro
 	wg.Wait()
 	t.logger.Info().Msg("terminating...")
 
+	t.warnDrops()
+
 	return t.writeReport(ReportFileName)
 }
 
-func (t *UserTracer) attachProbe(ctx context.Context) {
+// warnDrops reads the BPF drop counter and warns when calls could not be
+// recorded because seen_funcs was full: their functions are missing from
+// funcs_ack.
+func (t *UserTracer) warnDrops() {
+	drops, err := t.probe.Drops()
+	if err != nil {
+		t.logger.Warn().Err(err).Msg("failed to read dropped first hits counter")
+		return
+	}
+	if drops > 0 {
+		t.logger.Warn().Uint64("dropped", drops).
+			Msg("calls not recorded because the seen_funcs map is full; coverage is undercounted, narrow the probe set with --scope or --exclude")
+	}
+}
+
+func (t *UserTracer) attachProbe(ctx context.Context) error {
 	batchSize := bpfUprobeMultiAttachMaxOffsets
 
 	offsets, cookies := t.tracee.GetFuncProbes()
@@ -211,9 +232,11 @@ func (t *UserTracer) attachProbe(ctx context.Context) {
 		}
 
 		if err := t.probe.Attach(ctx, t.tracee.exePath, offsets[i:end], cookies[i:end]); err != nil {
-			t.logger.Warn().Err(errors.Wrapf(err, "error attaching uprobe for functions with cookies: %v", cookies[i:end]))
+			return err
 		}
 	}
+
+	return nil
 }
 
 func (t *UserTracer) ingestEvents(ctx context.Context, events <-chan []byte, feed chan<- []byte) {
@@ -300,17 +323,20 @@ func (t *UserTracer) writeReport(reportPath string) error {
 		traced = append(traced, fn.name)
 	}
 
+	// Skip cookies that do not resolve to a function instead of stopping the
+	// iteration, and derive the ratio from the names actually listed so
+	// cov_by_func always equals len(funcs_ack) / len(funcs_traced).
 	ack := make([]string, 0, utils.LenSyncMap(&t.ack))
 	t.ack.Range(func(k, v interface{}) bool {
 		fun, ok := t.tracee.funcs[k.(cookie)]
 		if !ok {
-			return false
+			return true
 		}
 		ack = append(ack, fun.name)
 		return true
 	})
 
-	covByFunc := float64(utils.LenSyncMap(&t.ack)) / float64(len(t.tracee.funcs)) * 100
+	covByFunc := float64(len(ack)) / float64(len(t.tracee.funcs)) * 100
 
 	report := coverage.NewCoverageReport(
 		coverage.WithReportFuncsAck(ack),
@@ -321,7 +347,7 @@ func (t *UserTracer) writeReport(reportPath string) error {
 
 	file, err := os.Create(reportPath)
 	if err != nil {
-		t.logger.Err(err).Msg("failed to create report file")
+		return errors.Wrap(err, "failed to create report file")
 	}
 	defer file.Close()
 

--- a/pkg/trace/tracer_options.go
+++ b/pkg/trace/tracer_options.go
@@ -9,6 +9,9 @@ import (
 type UserTracerOptions struct {
 	cookiesMapName string
 
+	// pid restricts tracing to one process; probe.PIDAll traces every process.
+	pid int
+
 	report       bool
 	status       bool
 	verbose      bool
@@ -59,5 +62,13 @@ func WithTracerTracee(tracee *UserTracee) UserTracerOpt {
 func WithTracerUserspaceBPF(enabled bool) UserTracerOpt {
 	return func(opts *UserTracer) {
 		opts.userspaceBPF = enabled
+	}
+}
+
+// WithTracerPID restricts tracing to the process with the given PID. The
+// default, probe.PIDAll, traces every process running the executable.
+func WithTracerPID(pid int) UserTracerOpt {
+	return func(opts *UserTracer) {
+		opts.pid = pid
 	}
 }

--- a/pkg/trace/tracer_test.go
+++ b/pkg/trace/tracer_test.go
@@ -3,9 +3,14 @@ package trace
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/maxgio92/xcover/pkg/coverage"
 )
 
 const (
@@ -49,8 +54,8 @@ func TestHandleEvent_Verbose(t *testing.T) {
 }
 
 // TestHandleEvent_UnknownCookie verifies that an event carrying a cookie not
-// present in tracee.funcs is still acked, matching the pre-refactor behavior
-// of counting unresolved cookies toward the reported coverage.
+// present in tracee.funcs is still acked; writeReport is responsible for
+// leaving such cookies out of the report.
 func TestHandleEvent_UnknownCookie(t *testing.T) {
 	var buf bytes.Buffer
 
@@ -78,4 +83,48 @@ func TestHandleEvent_UnknownCookie(t *testing.T) {
 
 	_, ok := tracer.ack.Load(cookie(2))
 	require.True(t, ok)
+}
+
+// TestWriteReport_UnknownCookie verifies that a cookie with no matching
+// function neither truncates funcs_ack nor inflates cov_by_func: the ratio is
+// derived from the names listed in funcs_ack. The old Range callback returned
+// false on the first unknown cookie, dropping every function visited after it.
+func TestWriteReport_UnknownCookie(t *testing.T) {
+	tracee := NewUserTracee(WithTraceeExePath("dummy-path"))
+	tracee.funcs = map[cookie]funcInfo{
+		1: {name: "pkg.Alpha"},
+		2: {name: "pkg.Beta"},
+		3: {name: "pkg.Gamma"},
+		4: {name: "pkg.Delta"},
+	}
+
+	tracer := NewUserTracer(WithTracerReport(true), WithTracerTracee(tracee))
+	for _, ck := range []cookie{1, 2, 99, 3} {
+		tracer.ack.Store(ck, struct{}{})
+	}
+
+	reportPath := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, tracer.writeReport(reportPath))
+
+	data, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+	var report coverage.CoverageReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	require.ElementsMatch(t, []string{"pkg.Alpha", "pkg.Beta", "pkg.Gamma"}, report.FuncsAck)
+	require.Len(t, report.FuncsTraced, 4)
+	require.InDelta(t, 75.0, report.CovByFunc, 1e-9)
+	require.Equal(t, "dummy-path", report.ExePath)
+}
+
+// TestWriteReport_CreateError verifies that a report path that cannot be
+// created is returned as an error so the run exits non-zero instead of
+// logging and reporting success.
+func TestWriteReport_CreateError(t *testing.T) {
+	tracee := NewUserTracee(WithTraceeExePath("dummy-path"))
+	tracee.funcs = map[cookie]funcInfo{1: {name: "pkg.Alpha"}}
+	tracer := NewUserTracer(WithTracerReport(true), WithTracerTracee(tracee))
+
+	err := tracer.writeReport(filepath.Join(t.TempDir(), "missing-dir", "report.json"))
+	require.ErrorContains(t, err, "failed to create report file")
 }


### PR DESCRIPTION
## Summary

Fix `--pid`, attach error handling, report accuracy, filter compilation and BPF logging. Based on #178 because both edit `README.md.tpl`.

## Changes

- Pass `--pid` to both attach paths and reject `0`, negatives other than `-1`, and values above `MaxInt32` (libbpfgo narrows the pid to a C int, so larger values wrapped to "all processes").
- Return `uprobe_multi` attach errors so `run` aborts before signalling readiness instead of reporting an inflated denominator.
- Stop truncating `funcs_ack` on an unknown cookie; compute `cov_by_func` from the listed names; return report file creation errors.
- Compile `--include` and `--exclude` once per resolver; an invalid pattern is an error, not a panic.
- Compile `bpf_printk` out unless `CFLAGS=-DDEBUG`; check the `seen_funcs` insert and count unrecorded calls in a `drops` map that the tracer warns about on exit.
- Map `aarch64` to `arm64` for `__TARGET_ARCH_`.
- CI: the `build` job fails when `README.md` or `docs/` differ from `make docs` output.
- README, architecture and contributor docs updated to match.

## Verification

`make test-integration` (all packages), `gofmt -l .` and `make docs` in the pinned `xcover-build` container.

## Known gap

Under `--userspace-bpf`, bpftime at the pinned commit does not enforce the uprobe pid and never reports a full hash map, so `--pid` and the drop warning apply to kernel mode only. #179 refuses the `--pid` combination.
