### PR TITLE
fix(run): reject --pid together with --userspace-bpf

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ xcover run --path EXE_PATH --pid 1234
 
 The process must exist when xcover attaches, otherwise the attach fails and
 xcover exits. Hits from other processes of the same executable are ignored.
+`--pid` is rejected together with `--userspace-bpf`, because bpftime does not
+enforce the filter; see [docs/userspace-bpf.md](docs/userspace-bpf.md#limitations).
 
 ## Symbolization
 
@@ -238,7 +240,7 @@ Notes on the numbers:
 - Coverage is per function. There is no line, branch or call-count information.
 - By default hits are aggregated across every process that ran the binary
   during the session, and the report does not say which process exercised a
-  function. Pass `--pid` to restrict tracing to one process.
+  function. Pass `--pid` (kernel mode only) to restrict tracing to one process.
 - An attach failure aborts the run before readiness is signalled and no report
   is written, so a report always covers every function in `funcs_traced`.
 - Past 40960 distinct functions the kernel map is full and further functions

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -150,6 +150,8 @@ xcover run --path EXE_PATH --pid 1234
 
 The process must exist when xcover attaches, otherwise the attach fails and
 xcover exits. Hits from other processes of the same executable are ignored.
+`--pid` is rejected together with `--userspace-bpf`, because bpftime does not
+enforce the filter; see [docs/userspace-bpf.md](docs/userspace-bpf.md#limitations).
 
 ## Symbolization
 
@@ -238,7 +240,7 @@ Notes on the numbers:
 - Coverage is per function. There is no line, branch or call-count information.
 - By default hits are aggregated across every process that ran the binary
   during the session, and the report does not say which process exercised a
-  function. Pass `--pid` to restrict tracing to one process.
+  function. Pass `--pid` (kernel mode only) to restrict tracing to one process.
 - An attach failure aborts the run before readiness is signalled and no report
   is written, so a report always covers every function in `funcs_traced`.
 - Past 40960 distinct functions the kernel map is full and further functions

--- a/docs/xcover_run.md
+++ b/docs/xcover_run.md
@@ -23,7 +23,7 @@ xcover run [flags]
       --include string      Regex pattern to include function symbol names
       --no-build-id-check   Skip GNU build-id verification between --path and --debug-path
   -p, --path string         Path to the ELF executable
-      --pid int             Only trace the process with this PID; -1 traces every process running the executable (default -1)
+      --pid int             Only trace the process with this PID (kernel mode only); -1 traces every process running the executable (default -1)
       --report              Generate report (as xcover-report.json) (default true)
       --scope string        Function scope: "binary" (all functions) or "project" (project module only, Go binaries) (default "binary")
       --status              Periodically print a status of the trace (default true)

--- a/docs/xcover_userspace_bpf.md
+++ b/docs/xcover_userspace_bpf.md
@@ -100,6 +100,11 @@ control, and for which we want the most transparent UX possible.
   startup; it cannot be used to inject into an already-running process.
 - **Dynamically linked binaries only.** See Requirements and the Binary
   support section.
+- **`--pid` is rejected.** bpftime at the pinned commit stores the PID filter
+  but never enforces it, so a positive `--pid` would silently record hits from
+  every process that loaded the agent. xcover refuses the combination at
+  startup with `--pid is not enforced by bpftime; drop it or run without
+  --userspace-bpf`.
 - **Self re-exec on first invocation.** The `--userspace-bpf` flag causes
   xcover to re-exec itself with the syscall-server preloaded and
   `XCOVER_BPFTIME_LOADED=1` set. Transparent in normal usage but may interact

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -56,7 +56,7 @@ It supports programs compiled to ELF.
 	}
 
 	cmd.Flags().StringVarP(&o.comm, "path", "p", "", "Path to the ELF executable")
-	cmd.Flags().IntVar(&o.pid, "pid", probe.PIDAll, "Only trace the process with this PID; -1 traces every process running the executable")
+	cmd.Flags().IntVar(&o.pid, "pid", probe.PIDAll, "Only trace the process with this PID (kernel mode only); -1 traces every process running the executable")
 
 	cmd.Flags().StringVar(&o.symExcludePattern, "exclude", "", "Regex pattern to exclude function symbol names")
 	cmd.Flags().StringVar(&o.symIncludePattern, "include", "", "Regex pattern to include function symbol names")
@@ -123,6 +123,13 @@ func (o *Options) setup() (trace.Scope, error) {
 	// value to a C int, so anything above MaxInt32 would wrap the same way.
 	if o.pid == 0 || o.pid < probe.PIDAll || o.pid > math.MaxInt32 {
 		return "", fmt.Errorf("--pid must be a positive PID up to %d or %d, got %d", math.MaxInt32, probe.PIDAll, o.pid)
+	}
+
+	// bpftime at the pinned commit stores the uprobe pid but never checks it,
+	// so a positive --pid would silently record hits from every process that
+	// loaded the agent.
+	if o.userspaceBPF && o.pid != probe.PIDAll {
+		return "", errors.New("--pid is not enforced by bpftime; drop it or run without --userspace-bpf")
 	}
 
 	scope, err := trace.ParseScope(o.scope)

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -39,11 +39,12 @@ func TestOptionsSetup(t *testing.T) {
 	t.Cleanup(func() { settings.PidFile = origPidFile })
 
 	tests := []struct {
-		name      string
-		scope     string
-		pid       int
-		wantScope trace.Scope
-		wantErr   bool
+		name         string
+		scope        string
+		pid          int
+		userspaceBPF bool
+		wantScope    trace.Scope
+		wantErr      bool
 	}{
 		{
 			name:      "binary scope",
@@ -100,6 +101,22 @@ func TestOptionsSetup(t *testing.T) {
 			pid:     math.MaxInt32 + 1,
 			wantErr: true,
 		},
+		{
+			// bpftime stores the pid but never enforces it, so the filter
+			// would silently trace every agent-loaded process.
+			name:         "positive pid with userspace BPF",
+			scope:        string(trace.ScopeBinary),
+			pid:          os.Getpid(),
+			userspaceBPF: true,
+			wantErr:      true,
+		},
+		{
+			name:         "PIDAll with userspace BPF",
+			scope:        string(trace.ScopeBinary),
+			pid:          probe.PIDAll,
+			userspaceBPF: true,
+			wantScope:    trace.ScopeBinary,
+		},
 	}
 
 	for _, tt := range tests {
@@ -107,6 +124,7 @@ func TestOptionsSetup(t *testing.T) {
 			o := newTestOptions(t)
 			o.scope = tt.scope
 			o.pid = tt.pid
+			o.userspaceBPF = tt.userspaceBPF
 
 			scope, err := o.setup()
 


### PR DESCRIPTION
## Summary

Under `--userspace-bpf`, bpftime at the pinned commit (`5bf24b21af85`) stores the uprobe pid but never compares it when hooking, so `--pid N` silently recorded hits from every process that had the agent preloaded. Based on #180.

## Changes

- `Options.setup()` rejects a positive `--pid` combined with `--userspace-bpf`:

  ```
  --pid is not enforced by bpftime; drop it or run without --userspace-bpf
  ```

- Table tests in `TestOptionsSetup` for the rejected and the allowed (`-1`) case.
- `--pid` help text marks the flag as kernel mode only; `docs/xcover_run.md` and `README.md` regenerated.
- The userspace guide's Limitations bullet states the combination is refused.

## Verification

`make test-integration TEST_PATH=./pkg/cmd/...`, `gofmt -l .` and `make docs` in the pinned `xcover-build` container.
