### PR TITLE
feat(demo): open a tmux log pane automatically

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -23,15 +23,29 @@ script from its directory:
 ```shell
 make xcover                    # or: make xcover-userspace
 cd demo/basic
-sudo bash demo.sh              # userspace scenarios run without sudo
+sudo --preserve-env=TMUX bash demo.sh   # userspace scenarios run without sudo
 ```
+
+## Log pane
+
+When a demo runs inside tmux it splits a pane on the right that tails
+`/tmp/xcover.log`, the file `xcover run --detach` writes to (the userspace
+scenarios tail `~/.bpftime/runtime.log` instead). sudo drops `TMUX` from the
+environment by default, so the kernel demos need `sudo --preserve-env=TMUX`
+(or a tmux server started as root) for the pane to open; with plain `sudo` the
+demo runs without a pane. On a BPF_DEBUG build (`make xcover/bpf BPF_DEBUG=1`,
+then rebuild xcover) set `XCOVER_DEMO_TRACE_PIPE=1` to tail the kernel trace
+pipe and see `bpf_printk` output. The trace pipe is root-only and the pane is
+spawned by the tmux server, so this only works when tmux itself runs as root;
+otherwise the pane prints a notice and falls back to the log file. The pane is
+closed when the demo exits. Outside tmux nothing changes.
 
 ## Record and publish
 
 ```shell
 cd demo/basic
 asciinema rec -t "xcover - Functional Test Coverage Profiler" \
-  --command "sudo ./demo.sh" xcover-demo.cast
+  --command "sudo --preserve-env=TMUX ./demo.sh" xcover-demo.cast
 asciinema upload xcover-demo.cast
 ```
 

--- a/demo/basic/demo.sh
+++ b/demo/basic/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Automated xcover demo for asciinema
-# Run as: sudo bash demo.sh
+# Run as: sudo --preserve-env=TMUX bash demo.sh   (TMUX is needed for the log pane)
 
 set -euo pipefail
 
@@ -9,7 +9,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP
@@ -25,6 +29,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Functional Test Coverage Profiler ==="
 	runCmd "# Profile coverage without instrumenting your binaries!"
@@ -62,4 +67,4 @@ function runCmd() {
 	sleep "${SLEEP}"
 }
 
-main $@
+main "$@"

--- a/demo/debugfile/demo.sh
+++ b/demo/debugfile/demo.sh
@@ -2,7 +2,7 @@
 # Automated xcover debug file demo for asciinema
 # Demonstrates coverage profiling on a stripped C binary using a separate
 # debug file to resolve function names.
-# Run as: sudo bash demo.sh
+# Run as: sudo --preserve-env=TMUX bash demo.sh   (TMUX is needed for the log pane)
 
 set -euo pipefail
 
@@ -12,7 +12,11 @@ DEBUG_FILE="./demo-app.debug"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP $DEBUG_FILE
@@ -28,6 +32,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Coverage with a separate debug file ==="
 	runCmd "# Strip the binary for production. Keep the debug file for profiling."
@@ -73,4 +78,4 @@ function runCmd() {
 	sleep "${SLEEP}"
 }
 
-main $@
+main "$@"

--- a/demo/lib/log-pane.sh
+++ b/demo/lib/log-pane.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# log-pane.sh - tmux log pane helper for xcover demos.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/log-pane.sh"
+#
+#   setup_log_pane kernel      # tail the xcover daemon log (/tmp/xcover.log)
+#   setup_log_pane userspace   # tail the bpftime runtime log ($HOME/.bpftime/runtime.log)
+#
+#   Call teardown_log_pane in your cleanup() function.
+#
+# Both functions are no-ops outside tmux. sudo drops TMUX from the
+# environment by default, so the kernel demos must run as
+# `sudo --preserve-env=TMUX bash demo.sh` (or inside a tmux server started as
+# root) for the pane to open.
+#
+# Kernel mode tails /tmp/xcover.log by default, the file `xcover run --detach`
+# writes to (settings.LogFile). Set XCOVER_DEMO_TRACE_PIPE=1 to tail the kernel
+# trace pipe instead, which shows bpf_printk output. That output is only
+# present when xcover was built with `make xcover/bpf BPF_DEBUG=1` and then
+# rebuilt. The pane command is forked by the tmux server, not by this (root)
+# process, so the trace pipe is only readable when the tmux server itself runs
+# as root; the pane script therefore picks its source with its own
+# credentials. tracefs (/sys/kernel/tracing) is preferred, with a fallback to
+# debugfs (/sys/kernel/debug/tracing). If neither is readable the pane falls
+# back to the daemon log and says so.
+
+# Preserve an open pane if this file is sourced twice.
+LOG_PANE="${LOG_PANE:-}"
+
+function setup_log_pane() {
+    [ -z "${TMUX:-}" ] && return 0
+    local mode="${1:-kernel}"
+    local log_file="/tmp/xcover.log"
+    local pane_cmd
+
+    if [ "${mode}" = "userspace" ]; then
+        log_file="${HOME}/.bpftime/runtime.log"
+        # Optional pane: never let a read-only HOME abort the demo.
+        mkdir -p "$(dirname "${log_file}")" 2>/dev/null || true
+    fi
+
+    # Create the file up front so tail -F has something to open; -F keeps
+    # following when the demo cleanup removes and xcover recreates it.
+    touch "${log_file}" 2>/dev/null || true
+    # The readability test must run inside the pane: tmux forks the pane
+    # command with the server's credentials, not this script's. $1 is the log
+    # file, passed as a positional argument and expanded by the pane's bash.
+    # shellcheck disable=SC2016
+    if [ "${mode}" = "kernel" ] && [ "${XCOVER_DEMO_TRACE_PIPE:-0}" = "1" ]; then
+        pane_cmd='for p in /sys/kernel/tracing/trace_pipe /sys/kernel/debug/tracing/trace_pipe; do [ -r "$p" ] && exec cat "$p"; done; echo "trace_pipe not readable, falling back to $1"; exec tail -n +1 -F "$1"'
+    else
+        pane_cmd='exec tail -n +1 -F "$1"'
+    fi
+
+    # -l 40% rather than -p 40: tmux 3.4 (Ubuntu 24.04) mis-parses -p and
+    # fails with "size missing"; -l with a percentage works on 3.1 and later.
+    # -d keeps focus on the demo pane, so no select-pane is needed.
+    if ! LOG_PANE="$(tmux split-window -d -h -l 40% -P -F '#{pane_id}' bash -c "${pane_cmd}" _ "${log_file}")"; then
+        LOG_PANE=""
+        echo "log pane: tmux split-window failed, continuing without pane" >&2
+    fi
+}
+
+function teardown_log_pane() {
+    if [ -n "${LOG_PANE:-}" ]; then
+        tmux kill-pane -t "${LOG_PANE}" 2>/dev/null || true
+    fi
+    LOG_PANE=""
+}

--- a/demo/stripped/demo.sh
+++ b/demo/stripped/demo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Automated xcover stripped binary demo for asciinema
 # Demonstrates coverage profiling on a stripped C binary via kernel uprobes.
-# Run as: sudo bash demo.sh
+# Run as: sudo --preserve-env=TMUX bash demo.sh   (TMUX is needed for the log pane)
 
 set -euo pipefail
 
@@ -10,7 +10,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f $DEMO_APP
@@ -26,6 +30,7 @@ function main() {
 	    exit 1
 	fi
 
+	setup_log_pane kernel
 	clear
 	runCmd "# === xcover: Coverage on stripped binaries ==="
 	runCmd "# No source instrumentation. No debug info. Just the binary."
@@ -66,4 +71,4 @@ function runCmd() {
 	sleep "${SLEEP}"
 }
 
-main $@
+main "$@"

--- a/demo/userspace-stripped/demo.sh
+++ b/demo/userspace-stripped/demo.sh
@@ -10,7 +10,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover-userspace"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f /dev/shm/bpftime_*
@@ -24,6 +28,7 @@ function cleanup() {
 trap cleanup EXIT
 
 function main() {
+	setup_log_pane userspace
 	clear
 	runCmd "# === xcover: Userspace BPF mode (powered by bpftime) ==="
 	runCmd "# Same coverage profiling. Zero kernel traps!"
@@ -70,4 +75,4 @@ function runCmd() {
 	sleep "${SLEEP}"
 }
 
-main $@
+main "$@"

--- a/demo/userspace/demo.sh
+++ b/demo/userspace/demo.sh
@@ -10,7 +10,11 @@ DEMO_APP="./demo-app"
 XCOVER="${SCRIPT_DIR}/../../xcover-userspace"
 SLEEP="${SLEEP:-2}"
 
+# shellcheck source=../lib/log-pane.sh
+source "${SCRIPT_DIR}/../lib/log-pane.sh"
+
 function cleanup() {
+    teardown_log_pane
     ${XCOVER} stop 2>/dev/null || true
     pkill -f "${XCOVER} run" 2>/dev/null || true
     rm -f /dev/shm/bpftime_*
@@ -24,6 +28,7 @@ function cleanup() {
 trap cleanup EXIT
 
 function main() {
+	setup_log_pane userspace
 	clear
 	runCmd "# === xcover: Userspace BPF mode (powered by bpftime) ==="
 	runCmd "# Same coverage profiling. Zero kernel traps!"
@@ -69,4 +74,4 @@ function runCmd() {
 	sleep "${SLEEP}"
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
When a demo script runs inside tmux it opens a right pane that tails the relevant log while the demo plays; outside tmux nothing changes. Kernel demos tail `/tmp/xcover.log`, or the kernel trace pipe with `XCOVER_DEMO_TRACE_PIPE=1` on a `BPF_DEBUG` build; userspace demos tail the bpftime runtime log. The pane script picks its source with the tmux server's credentials and falls back to the log file with a notice, paths are passed as positional arguments so quoting is stable, `split-window -l 40%` avoids the tmux 3.4 `-p` bug, a failed split never aborts the demo, and the docs note that `sudo` must keep `TMUX`.

`shellcheck -S warning` is clean on all demo scripts and a tmux smoke test shows the pane appearing on setup and gone after teardown.

Supersedes #130.
